### PR TITLE
Various enhancements/fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,2 @@
+[workspace]
+members = ["pam", "pam-sober", "pam-http"]

--- a/pam-http/Cargo.toml
+++ b/pam-http/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pam = { path = "../pam/" }
-reqwest = "0.7"
+reqwest = { version = "0.11.3", features = ["blocking"] }

--- a/pam-http/Justfile
+++ b/pam-http/Justfile
@@ -3,10 +3,10 @@ all:
     cargo build
 
 install:
-    @cargo build
+    @cargo build --release
     sudo cp conf/http-auth /etc/pam.d/
-    sudo cp target/debug/libpam_http.so /lib/security/pam_http.so
+    sudo cp ../target/release/libpam_http.so /lib/security/pam_http.so
 
 test:
     @just install
-    gcc -o target/pam_test test.c -lpam -lpam_misc
+    gcc -o ../target/pam_test test.c -lpam -lpam_misc

--- a/pam-http/src/lib.rs
+++ b/pam-http/src/lib.rs
@@ -1,46 +1,35 @@
-#[macro_use] extern crate pam;
+extern crate pam;
 extern crate reqwest;
 
+use pam::constants::{PamFlag, PamResultCode, PAM_PROMPT_ECHO_OFF};
+use pam::conv::Conv;
 use pam::module::{PamHandle, PamHooks};
-use pam::constants::{PamResultCode, PamFlag, PAM_PROMPT_ECHO_OFF};
-use pam::conv::PamConv;
+use reqwest::blocking::Client;
+use reqwest::StatusCode;
 use std::collections::HashMap;
-use std::time::Duration;
-use reqwest::{Client, StatusCode};
 use std::ffi::CStr;
-
-
-macro_rules! pam_try {
-    ($e:expr) => (
-        match $e {
-            Ok(v) => v,
-            Err(e) => return e,
-        }
-    );
-    ($e:expr, $err:expr) => (
-        match $e {
-            Ok(v) => v,
-            Err(e) => {
-                println!("Error: {}", e);
-                return $err;
-            }
-        }
-    );
-}
+use std::time::Duration;
+use pam::pam_try;
 
 struct PamHttp;
-pam_hooks!(PamHttp);
+pam::pam_hooks!(PamHttp);
 
 impl PamHooks for PamHttp {
     // This function performs the task of authenticating the user.
-    fn sm_authenticate(pamh: &PamHandle, args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
+    fn sm_authenticate(pamh: &mut PamHandle, args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
         println!("Let's auth over HTTP");
 
-        let args: Vec<_> = args.iter().map(|s| s.to_string_lossy().to_owned() ).collect();
-        let args: HashMap<&str, &str> = args.iter().map(|s| {
-            let mut parts = s.splitn(2, "=");
-            (parts.next().unwrap(), parts.next().unwrap_or(""))
-        }).collect();
+        let args: Vec<_> = args
+            .iter()
+            .map(|s| s.to_string_lossy())
+            .collect();
+        let args: HashMap<&str, &str> = args
+            .iter()
+            .map(|s| {
+                let mut parts = s.splitn(2, '=');
+                (parts.next().unwrap(), parts.next().unwrap_or(""))
+            })
+            .collect();
 
         let user = pam_try!(pamh.get_user(None));
 
@@ -48,18 +37,27 @@ impl PamHooks for PamHttp {
             Some(url) => url,
             None => return PamResultCode::PAM_AUTH_ERR,
         };
-        // let ca_file = args.get("ca_file");
 
-        let conv = match pamh.get_item::<PamConv>() {
-            Ok(conv) => conv,
+        let conv = match pamh.get_item::<Conv>() {
+            Ok(Some(conv)) => conv,
+            Ok(None) => {
+                unreachable!("No conv available");
+            }
             Err(err) => {
                 println!("Couldn't get pam_conv");
                 return err;
             }
         };
         let password = pam_try!(conv.send(PAM_PROMPT_ECHO_OFF, "Word, yo: "));
+        let password = match password {
+            Some(password) => Some(pam_try!(password.to_str(), PamResultCode::PAM_AUTH_ERR)),
+            None => None,
+        };
         println!("Got a password {:?}", password);
-        let status = pam_try!(get_url(url, &user, password.as_ref().map(|p|&**p)), PamResultCode::PAM_AUTH_ERR);
+        let status = pam_try!(
+            get_url(url, &user, password),
+            PamResultCode::PAM_AUTH_ERR
+        );
 
         if !status.is_success() {
             println!("HTTP Error: {}", status);
@@ -69,24 +67,22 @@ impl PamHooks for PamHttp {
         PamResultCode::PAM_SUCCESS
     }
 
-    fn sm_setcred(_pamh: &PamHandle, _args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
+    fn sm_setcred(_pamh: &mut PamHandle, _args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
         println!("set credentials");
         PamResultCode::PAM_SUCCESS
     }
 
-    fn acct_mgmt(_pamh: &PamHandle, _args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
+    fn acct_mgmt(_pamh: &mut PamHandle, _args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
         println!("account management");
         PamResultCode::PAM_SUCCESS
     }
 }
 
-
 fn get_url(url: &str, user: &str, password: Option<&str>) -> reqwest::Result<StatusCode> {
-    let client = Client::builder()?.timeout(Duration::from_secs(15)).build()?;
-    client.get(url)?
+    let client = Client::builder().timeout(Duration::from_secs(15)).build()?;
+    client
+        .get(url)
         .basic_auth(user, password)
         .send()
         .map(|r| r.status())
 }
-
-

--- a/pam-sober/Cargo.toml
+++ b/pam-sober/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pam = { path = "../pam/" }
-rand = "0.3.16"
+rand = "0.8.4"

--- a/pam-sober/Justfile
+++ b/pam-sober/Justfile
@@ -3,10 +3,10 @@ all:
     cargo build
 
 install:
-    @cargo build
+    @cargo build --release
     sudo cp conf/sober-auth /etc/pam.d/
-    sudo cp target/debug/libpam_sober.so /lib/security/pam_sober.so
+    sudo cp ../target/release/libpam_sober.so /lib/security/pam_sober.so
 
 test:
     @just install
-    gcc -o target/pam_test test.c -lpam -lpam_misc
+    gcc -o ../target/pam_test test.c -lpam -lpam_misc

--- a/pam-sober/src/lib.rs
+++ b/pam-sober/src/lib.rs
@@ -1,37 +1,20 @@
-#[macro_use] extern crate pam;
+extern crate pam;
 extern crate rand;
 
+use pam::constants::{PamFlag, PamResultCode, PAM_PROMPT_ECHO_ON};
+use pam::conv::Conv;
 use pam::module::{PamHandle, PamHooks};
-use pam::constants::{PamResultCode, PamFlag, PAM_PROMPT_ECHO_ON};
-use pam::conv::PamConv;
 use rand::Rng;
-use std::str::FromStr;
 use std::ffi::CStr;
-
-macro_rules! pam_try {
-    ($e:expr) => (
-        match $e {
-            Ok(v) => v,
-            Err(e) => return e,
-        }
-    );
-    ($e:expr, $err:expr) => (
-        match $e {
-            Ok(v) => v,
-            Err(e) => {
-                println!("Error: {}", e);
-                return $err;
-            }
-        }
-    );
-}
+use std::str::FromStr;
+use pam::pam_try;
 
 struct PamSober;
-pam_hooks!(PamSober);
+pam::pam_hooks!(PamSober);
 
 impl PamHooks for PamSober {
     // This function performs the task of authenticating the user.
-    fn sm_authenticate(pamh: &PamHandle, _args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
+    fn sm_authenticate(pamh: &mut PamHandle, _args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
         println!("Let's make sure you're sober enough to perform basic addition");
 
         /* TODO: use args to change difficulty ;-)
@@ -44,8 +27,9 @@ impl PamHooks for PamSober {
         // TODO: maybe we can change difficulty base on user?
         // let user = pam_try!(pam.get_user(None));
 
-        let conv = match pamh.get_item::<PamConv>() {
-            Ok(conv) => conv,
+        let conv = match pamh.get_item::<Conv>() {
+            Ok(Some(conv)) => conv,
+            Ok(None) => todo!(),
             Err(err) => {
                 println!("Couldn't get pam_conv");
                 return err;
@@ -58,24 +42,31 @@ impl PamHooks for PamSober {
         let math = format!("{} + {} = ", a, b);
 
         // This println kinda helps debugging since the test script doesn't echo
-        println!("{}", math);
+        eprintln!("[DEBUG]: {}{}", math, a + b);
 
         let password = pam_try!(conv.send(PAM_PROMPT_ECHO_ON, &math));
 
-        if password.and_then(|p| u32::from_str(&p).ok()) == Some(a+b) {
-            return PamResultCode::PAM_SUCCESS;
+        if let Some(password) = password {
+            let password = pam_try!(password.to_str(), PamResultCode::PAM_AUTH_ERR);
+            let answer = pam_try!(u32::from_str(password), PamResultCode::PAM_AUTH_ERR);
+            if answer == a + b {
+                PamResultCode::PAM_SUCCESS
+            } else {
+                println!("Wrong answer provided {} + {} != {}", a, b, answer);
+                PamResultCode::PAM_AUTH_ERR
+            }
+        } else {
+            println!("You failed the PAM sobriety test.");
+            PamResultCode::PAM_AUTH_ERR
         }
-
-        println!("You failed the PAM sobriety test.");
-        return PamResultCode::PAM_AUTH_ERR;
     }
 
-    fn sm_setcred(_pamh: &PamHandle, _args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
+    fn sm_setcred(_pamh: &mut PamHandle, _args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
         println!("set credentials");
         PamResultCode::PAM_SUCCESS
     }
 
-    fn acct_mgmt(_pamh: &PamHandle, _args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
+    fn acct_mgmt(_pamh: &mut PamHandle, _args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
         println!("account management");
         PamResultCode::PAM_SUCCESS
     }

--- a/pam-sober/test.c
+++ b/pam-sober/test.c
@@ -23,18 +23,19 @@ int main(int argc, char *argv[]) {
 
 	// Are the credentials correct?
 	if (retval == PAM_SUCCESS) {
-		printf("Credentials accepted.\n");
+		printf("PAM module initialized\n");
 		retval = pam_authenticate(pamh, 0);
 	}
 
 	// Can the accound be used at this time?
 	if (retval == PAM_SUCCESS) {
-		printf("Account is valid.\n");
+		printf("Credentials accepted.\n");
 		retval = pam_acct_mgmt(pamh, 0);
 	}
 
 	// Did everything work?
 	if (retval == PAM_SUCCESS) {
+		printf("Account is valid.\n");
 		printf("Authenticated\n");
 	} else {
 		printf("Not Authenticated\n");

--- a/pam/Cargo.toml
+++ b/pam/Cargo.toml
@@ -13,4 +13,4 @@ license = "MIT"
 name = "pam"
 
 [dependencies]
-libc = "~0.1.5"
+libc = "0.2.97"

--- a/pam/src/constants.rs
+++ b/pam/src/constants.rs
@@ -5,7 +5,6 @@ use libc::{c_int, c_uint};
 pub type PamFlag = c_uint;
 pub type PamItemType = c_int;
 pub type PamMessageStyle = c_int;
-pub type AlwaysZero = c_int;
 
 // The Linux-PAM flags
 // see /usr/include/security/_pam_types.h
@@ -16,36 +15,6 @@ pub const PAM_DELETE_CRED: PamFlag = 0x0004;
 pub const PAM_REINITIALIZE_CRED: PamFlag = 0x0008;
 pub const PAM_REFRESH_CRED: PamFlag = 0x0010;
 pub const PAM_CHANGE_EXPIRED_AUTHTOK: PamFlag = 0x0020;
-
-// The Linux-PAM item types
-// see /usr/include/security/_pam_types.h
-/// The service name
-pub const PAM_SERVICE: PamItemType = 1;
-/// The user name
-pub const PAM_USER: PamItemType = 2;
-/// The tty name
-pub const PAM_TTY: PamItemType = 3;
-/// The remote host name
-pub const PAM_RHOST: PamItemType = 4;
-/// The pam_conv structure
-pub const PAM_CONV: PamItemType = 5;
-/// The authentication token (password)
-pub const PAM_AUTHTOK: PamItemType = 6;
-/// The old authentication token
-pub const PAM_OLDAUTHTOK: PamItemType = 7;
-/// The remote user name
-pub const PAM_RUSER: PamItemType = 8;
-/// the prompt for getting a username
-pub const PAM_USER_PROMPT: PamItemType = 9;
-/* Linux-PAM :extensionsPamItemType = */
-/// app supplied function to override failure delays
-pub const PAM_FAIL_DELAY: PamItemType = 10;
-/// X :display name
-pub const PAM_XDISPLAY: PamItemType = 11;
-/// X :server authentication data
-pub const PAM_XAUTHDATA: PamItemType = 12;
-/// The type for pam_get_authtok
-pub const PAM_AUTHTOK_TYPE: PamItemType = 13;
 
 // Message styles
 pub const PAM_PROMPT_ECHO_OFF: PamMessageStyle = 1;

--- a/pam/src/items.rs
+++ b/pam/src/items.rs
@@ -1,69 +1,88 @@
-use constants::{PamItemType, PAM_SERVICE, PAM_USER, PAM_USER_PROMPT, PAM_TTY, PAM_RUSER, PAM_RHOST,
-                PAM_AUTHTOK, PAM_OLDAUTHTOK};
-use module::PamItem;
-pub use conv::PamConv;
-
-
-pub struct PamService {}
-
-impl PamItem for PamService {
-    fn item_type() -> PamItemType {
-        PAM_SERVICE
-    }
+#[repr(u32)]
+pub enum ItemType {
+    /// The service name
+    Service = 1,
+    /// The user name
+    User = 2,
+    /// The tty name
+    Tty = 3,
+    /// The remote host name
+    RHost = 4,
+    /// The pam_conv structure
+    Conv = 5,
+    /// The authentication token (password)
+    AuthTok = 6,
+    /// The old authentication token
+    OldAuthTok = 7,
+    /// The remote user name
+    RUser = 8,
+    /// the prompt for getting a username
+    UserPrompt = 9,
+    /// app supplied function to override failure delays
+    FailDelay = 10,
+    /// X :display name
+    XDisplay = 11,
+    /// X :server authentication data
+    XAuthData = 12,
+    /// The type for pam_get_authtok
+    AuthTokType = 13,
 }
 
-pub struct PamUser {}
+// A type that can be requested by `pam::Handle::get_item`.
+pub trait Item {
+    /// The `repr(C)` type that is returned (by pointer) by the underlying `pam_get_item` function.
+    type Raw;
 
-impl PamItem for PamUser {
-    fn item_type() -> PamItemType {
-        PAM_USER
-    }
+    /// The `ItemType` for this type
+    fn type_id() -> ItemType;
+
+    /// The function to convert from the pointer to the C-representation to this safer wrapper type
+    ///
+    /// # Safety
+    ///
+    /// This function can assume the pointer is a valid pointer to a `Self::Raw` instance.
+    unsafe fn from_raw(raw: *const Self::Raw) -> Self;
+
+    /// The function to convert from this wrapper type to a C-compatible pointer.
+    fn into_raw(self) -> *const Self::Raw;
 }
 
-pub struct PamUserPrompt {}
+macro_rules! cstr_item {
+    ($name:ident) => {
+        #[derive(Debug)]
+        pub struct $name<'s>(pub &'s std::ffi::CStr);
 
-impl PamItem for PamUserPrompt {
-    fn item_type() -> PamItemType {
-        PAM_USER_PROMPT
-    }
+        impl<'s> std::ops::Deref for $name<'s> {
+            type Target = &'s std::ffi::CStr;
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl<'s> Item for $name<'s> {
+            type Raw = libc::c_char;
+
+            fn type_id() -> ItemType {
+                ItemType::$name
+            }
+
+            unsafe fn from_raw(raw: *const Self::Raw) -> Self {
+                Self(std::ffi::CStr::from_ptr(raw))
+            }
+
+            fn into_raw(self) -> *const Self::Raw {
+                self.0.as_ptr()
+            }
+        }
+    };
 }
 
-pub struct PamTty {}
-
-impl PamItem for PamTty {
-    fn item_type() -> PamItemType {
-        PAM_TTY
-    }
-}
-
-pub struct PamRUser {}
-
-impl PamItem for PamRUser {
-    fn item_type() -> PamItemType {
-        PAM_RUSER
-    }
-}
-
-pub struct PamRHost {}
-
-impl PamItem for PamRHost {
-    fn item_type() -> PamItemType {
-        PAM_RHOST
-    }
-}
-
-pub struct PamAuthTok {}
-
-impl PamItem for PamAuthTok {
-    fn item_type() -> PamItemType {
-        PAM_AUTHTOK
-    }
-}
-
-pub struct PamOldAuthTok {}
-
-impl PamItem for PamOldAuthTok {
-    fn item_type() -> PamItemType {
-        PAM_OLDAUTHTOK
-    }
-}
+cstr_item!(Service);
+cstr_item!(User);
+cstr_item!(Tty);
+cstr_item!(RHost);
+// Conv
+cstr_item!(AuthTok);
+cstr_item!(OldAuthTok);
+cstr_item!(RUser);
+cstr_item!(UserPrompt);

--- a/pam/src/lib.rs
+++ b/pam/src/lib.rs
@@ -26,9 +26,9 @@
 
 extern crate libc;
 
+pub mod constants;
+pub mod conv;
+pub mod items;
 #[doc(hidden)]
 pub mod macros;
-pub mod conv;
-pub mod constants;
-pub mod items;
 pub mod module;

--- a/pam/src/macros.rs
+++ b/pam/src/macros.rs
@@ -18,12 +18,12 @@
 /// pam_hooks!(MyPamModule);
 ///
 /// impl PamHooks for MyPamModule {
-///	   fn sm_authenticate(pamh: &PamHandle, args: Vec<&CStr>, flags: PamFlag) -> PamResultCode {
+///    fn sm_authenticate(pamh: &mut PamHandle, args: Vec<&CStr>, flags: PamFlag) -> PamResultCode {
 ///        println!("Everybody is authenticated!");
 ///        PamResultCode::PAM_SUCCESS
 ///    }
 ///
-///    fn acct_mgmt(pamh: &PamHandle, args: Vec<&CStr>, flags: PamFlag) -> PamResultCode {
+///    fn acct_mgmt(pamh: &mut PamHandle, args: Vec<&CStr>, flags: PamFlag) -> PamResultCode {
 ///        println!("Everybody is authorized!");
 ///        PamResultCode::PAM_SUCCESS
 ///    }
@@ -31,97 +31,111 @@
 /// ```
 #[macro_export]
 macro_rules! pam_hooks {
-	($ident:ident) => (
-		pub use self::pam_hooks_scope::*;
-		mod pam_hooks_scope {
-			use $crate::module::{PamHandle, PamHooks};
-			use $crate::constants::{PamFlag, PamResultCode};
-			use std::ffi::CStr;
-			use std::os::raw::{c_char, c_int};
+    ($ident:ident) => {
+        pub use self::pam_hooks_scope::*;
+        mod pam_hooks_scope {
+            use std::ffi::CStr;
+            use std::os::raw::{c_char, c_int};
+            use $crate::constants::{PamFlag, PamResultCode};
+            use $crate::module::{PamHandle, PamHooks};
 
-			fn extract_argv<'a>(argc: c_int, argv: *const *const c_char) -> Vec<&'a CStr> {
-				(0..argc)
-					.map(|o| unsafe {
-						CStr::from_ptr(*argv.offset(o as isize) as *const c_char)
-					})
-					.collect()
-			}
+            fn extract_argv<'a>(argc: c_int, argv: *const *const c_char) -> Vec<&'a CStr> {
+                (0..argc)
+                    .map(|o| unsafe { CStr::from_ptr(*argv.offset(o as isize) as *const c_char) })
+                    .collect()
+            }
 
-			#[no_mangle]
-			pub extern "C" fn pam_sm_acct_mgmt(
-				pamh: &PamHandle,
-				flags: PamFlag,
-				argc: c_int,
-				argv: *const *const c_char,
-			) -> PamResultCode {
-				let args = extract_argv(argc, argv);
-				super::$ident::acct_mgmt(pamh, args, flags)
-			}
+            #[no_mangle]
+            pub extern "C" fn pam_sm_acct_mgmt(
+                pamh: &mut PamHandle,
+                flags: PamFlag,
+                argc: c_int,
+                argv: *const *const c_char,
+            ) -> PamResultCode {
+                let args = extract_argv(argc, argv);
+                super::$ident::acct_mgmt(pamh, args, flags)
+            }
 
-			#[no_mangle]
-			pub extern "C" fn pam_sm_authenticate(
-				pamh: &PamHandle,
-				flags: PamFlag,
-				argc: c_int,
-				argv: *const *const c_char,
-			) -> PamResultCode {
-				let args = extract_argv(argc, argv);
-				super::$ident::sm_authenticate(pamh, args, flags)
-			}
+            #[no_mangle]
+            pub extern "C" fn pam_sm_authenticate(
+                pamh: &mut PamHandle,
+                flags: PamFlag,
+                argc: c_int,
+                argv: *const *const c_char,
+            ) -> PamResultCode {
+                let args = extract_argv(argc, argv);
+                super::$ident::sm_authenticate(pamh, args, flags)
+            }
 
-			#[no_mangle]
-			pub extern "C" fn pam_sm_chauthtok(
-				pamh: &PamHandle,
-				flags: PamFlag,
-				argc: c_int,
-				argv: *const *const c_char,
-			) -> PamResultCode {
-				let args = extract_argv(argc, argv);
-				super::$ident::sm_chauthtok(pamh, args, flags)
-			}
+            #[no_mangle]
+            pub extern "C" fn pam_sm_chauthtok(
+                pamh: &mut PamHandle,
+                flags: PamFlag,
+                argc: c_int,
+                argv: *const *const c_char,
+            ) -> PamResultCode {
+                let args = extract_argv(argc, argv);
+                super::$ident::sm_chauthtok(pamh, args, flags)
+            }
 
-			#[no_mangle]
-			pub extern "C" fn pam_sm_close_session(
-				pamh: &PamHandle,
-				flags: PamFlag,
-				argc: c_int,
-				argv: *const *const c_char,
-			) -> PamResultCode {
-				let args = extract_argv(argc, argv);
-				super::$ident::sm_close_session(pamh, args, flags)
-			}
+            #[no_mangle]
+            pub extern "C" fn pam_sm_close_session(
+                pamh: &mut PamHandle,
+                flags: PamFlag,
+                argc: c_int,
+                argv: *const *const c_char,
+            ) -> PamResultCode {
+                let args = extract_argv(argc, argv);
+                super::$ident::sm_close_session(pamh, args, flags)
+            }
 
-			#[no_mangle]
-			pub extern "C" fn pam_sm_open_session(
-				pamh: &PamHandle,
-				flags: PamFlag,
-				argc: c_int,
-				argv: *const *const c_char,
-			) -> PamResultCode {
-				let args = extract_argv(argc, argv);
-				super::$ident::sm_open_session(pamh, args, flags)
-			}
+            #[no_mangle]
+            pub extern "C" fn pam_sm_open_session(
+                pamh: &mut PamHandle,
+                flags: PamFlag,
+                argc: c_int,
+                argv: *const *const c_char,
+            ) -> PamResultCode {
+                let args = extract_argv(argc, argv);
+                super::$ident::sm_open_session(pamh, args, flags)
+            }
 
-			#[no_mangle]
-			pub extern "C" fn pam_sm_setcred(
-				pamh: &PamHandle,
-				flags: PamFlag,
-				argc: c_int,
-				argv: *const *const c_char,
-			) -> PamResultCode {
-				let args = extract_argv(argc, argv);
-				super::$ident::sm_setcred(pamh, args, flags)
-			}
-		}
-	)
+            #[no_mangle]
+            pub extern "C" fn pam_sm_setcred(
+                pamh: &mut PamHandle,
+                flags: PamFlag,
+                argc: c_int,
+                argv: *const *const c_char,
+            ) -> PamResultCode {
+                let args = extract_argv(argc, argv);
+                super::$ident::sm_setcred(pamh, args, flags)
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! pam_try {
+    ($r:expr) => {
+        match $r {
+            Ok(t) => t,
+            Err(e) => return e,
+        }
+    };
+    ($r:expr, $e:expr) => {
+        match $r {
+            Ok(t) => t,
+            Err(_) => return $e,
+        }
+    };
 }
 
 #[cfg(test)]
 pub mod test {
-	use module::PamHooks;
+    use module::PamHooks;
 
-	struct Foo;
-	impl PamHooks for Foo {}
+    struct Foo;
+    impl PamHooks for Foo {}
 
-	pam_hooks!(Foo);
+    pam_hooks!(Foo);
 }


### PR DESCRIPTION
Sorry this is a bit of a mass of changes, if you're interested in some of these I can break out the individual changes into separate MRs, but I thought I'd send you this to get a conversation rolling.

* Move to 2021 edition (and apply edition idioms)
* Create a workspace so all the crates share compiler caches
    * Required fiddling with the Justfiles in the sample modules since the build output is in a different place now
* Bumped a bunch of dependencies to latest stable releases
* Ensure all FFI objects are FFI-safe (fixes #6)
* Create an `Item` trait that encapsulates "something that can be stored in a PAM item" which handles the conversions from Rust <-> C via raw pointers.
    * This means most items are now represented as `&OsStr` instances in the Rust code (since that's what they are in the C code)
* Fixes for various clippy lints
* Run rustfmt