### PR TITLE
Automate crate publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,29 +8,29 @@ name: Build & publish
 
 jobs:
   build:
-  runs-on: ubuntu-latest
-  steps:
-    - name: Use cargo cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Install stable toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - name: Publish module
-      uses: katyo/publish-crates@v1
-      with:
-        registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        check-repo: ${{ github.event_name == 'push' }}
-        ignore-unpublished-changes: true
-        # Only publish pam module, as pam-http and pam-sober are example projects
-        args: --package pam-bindings
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use cargo cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Publish module
+        uses: katyo/publish-crates@v1
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          check-repo: ${{ github.event_name == 'push' }}
+          ignore-unpublished-changes: true
+          # Only publish pam module, as pam-http and pam-sober are example projects
+          args: --package pam-bindings

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,4 +37,5 @@ jobs:
           check-repo: ${{ github.event_name == 'push' }}
           ignore-unpublished-changes: true
           # Only publish pam module, as pam-http and pam-sober are example projects
+          path: pam
           args: --package pam-bindings

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,76 +1,13 @@
 on:
-  pull_request:
+  push:
     branches:
       - master
   workflow_call:
 
-name: Build
+name: Build & publish
 
 jobs:
-  check:
-    name: Check & Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install PAM dev files
-        run: sudo apt-get install -y libpam0g-dev
-
-      - name: Use cargo cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path pam/Cargo.toml
-
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path pam/Cargo.toml
-
-      - name: Run cargo check on pam-http
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path pam-http/Cargo.toml
-
-      - name: Run cargo check on pam-sober
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path pam-sober/Cargo.toml
-
-      - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --manifest-path pam/Cargo.toml --all --check
-
-      - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path pam/Cargo.toml -- -D warnings
-  build:
+    build:
     needs: check
     runs-on: ubuntu-latest
     steps:
@@ -99,4 +36,3 @@ jobs:
           ignore-unpublished-changes: true
           # Only publish pam module, as pam-http and pam-sober are example projects
           args: --package pam-bindings
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install PAM dev files
+        run: sudo apt-get install -y libpam0g-dev
       - name: Use cargo cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,5 +70,33 @@ jobs:
         with:
           command: clippy
           args: --manifest-path pam/Cargo.toml -- -D warnings
+  build:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use cargo cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Publish module
+        uses: katyo/publish-crates@v1
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          check-repo: ${{ github.event_name == 'push' }}
+          ignore-unpublished-changes: true
+          # Only publish pam module, as pam-http and pam-sober are example projects
+          args: --package pam-bindings
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,32 +7,30 @@ on:
 name: Build & publish
 
 jobs:
-    build:
-    needs: check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Use cargo cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Publish module
-        uses: katyo/publish-crates@v1
-        with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          check-repo: ${{ github.event_name == 'push' }}
-          ignore-unpublished-changes: true
-          # Only publish pam module, as pam-http and pam-sober are example projects
-          args: --package pam-bindings
+  build:
+  runs-on: ubuntu-latest
+  steps:
+    - name: Use cargo cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Install stable toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - name: Publish module
+      uses: katyo/publish-crates@v1
+      with:
+        registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        check-repo: ${{ github.event_name == 'push' }}
+        ignore-unpublished-changes: true
+        # Only publish pam module, as pam-http and pam-sober are example projects
+        args: --package pam-bindings

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,72 @@
+on:
+  pull_request:
+    branches:
+      - master
+  workflow_call:
+
+name: Check
+
+jobs:
+  check:
+    name: Check & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install PAM dev files
+        run: sudo apt-get install -y libpam0g-dev
+
+      - name: Use cargo cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --manifest-path pam/Cargo.toml
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path pam/Cargo.toml
+
+      - name: Run cargo check on pam-http
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --manifest-path pam-http/Cargo.toml
+
+      - name: Run cargo check on pam-sober
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --manifest-path pam-sober/Cargo.toml
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --manifest-path pam/Cargo.toml --all --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path pam/Cargo.toml -- -D warnings

--- a/pam-http/Cargo.toml
+++ b/pam-http/Cargo.toml
@@ -8,5 +8,5 @@ name = "pam_http"
 crate-type = ["cdylib"]
 
 [dependencies]
-pam = { path = "../pam/" }
+pam-bindings = { path = "../pam/" }
 reqwest = { version = "0.11.3", features = ["blocking"] }

--- a/pam-sober/Cargo.toml
+++ b/pam-sober/Cargo.toml
@@ -8,5 +8,5 @@ name = "pam_sober"
 crate-type = ["cdylib"]
 
 [dependencies]
-pam = { path = "../pam/" }
+pam-bindings = { path = "../pam/" }
 rand = "0.8.4"

--- a/pam/Cargo.toml
+++ b/pam/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "pam-bindings"
 description = "PAM bindings for Rust"
-version = "0.1.0"
+version = "0.1.1"
 authors = [ "Anthony Nowell <anowell@gmail.com>" ]
 repository = "https://github.com/anowell/pam-rs"
 readme = "../README.md"

--- a/pam/Cargo.toml
+++ b/pam/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 
-name = "pam"
+name = "pam-bindings"
 description = "PAM bindings for Rust"
 version = "0.1.0"
 authors = [ "Anthony Nowell <anowell@gmail.com>" ]
 repository = "https://github.com/anowell/pam-rs"
-readme = "README.md"
+readme = "../README.md"
 keywords = ["pam", "ffi", "linux", "authentication"]
 license = "MIT"
 


### PR DESCRIPTION
Hello, I quite enjoy this project, and noticed #7, so thought i'd contribute and fix it.

I managed to snack this crate name https://crates.io/crates/pam-bindings, which I think fit pretty well (The readme even mentions bindings). These CI changes move the existing linting+testing on pull requests into check.yml, and changes build.yml to build and publish to crates.io.