### PR TITLE
Implemented get_authtok()/pam_get_authtok().

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["pam", "pam-sober", "pam-http"]
+members = ["pam", "pam-sober", "pam-http", "pam-sober-2"]

--- a/pam-sober-2/Cargo.toml
+++ b/pam-sober-2/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "pam-sober-2"
+version = "0.1.0"
+authors = ["Anthony Nowell <anowell@gmail.com>"]
+
+[lib]
+name = "pam_sober_2"
+crate-type = ["cdylib"]
+
+[dependencies]
+pam-bindings = { path = "../pam/" }
+rand = "0.8.4"

--- a/pam-sober-2/Justfile
+++ b/pam-sober-2/Justfile
@@ -1,0 +1,16 @@
+
+all:
+    cargo build
+
+install:
+    @cargo build --release
+    sudo cp conf/sober-auth-2 /etc/pam.d/
+    sudo cp ../target/release/libpam_sober_2.so /lib/security/pam_sober_2.so
+
+test:
+    @just install
+    gcc -o ../target/pam_test test.c -lpam -lpam_misc
+
+clean:
+    cargo clean
+

--- a/pam-sober-2/conf/sober-auth-2
+++ b/pam-sober-2/conf/sober-auth-2
@@ -1,0 +1,2 @@
+auth sufficient pam_sober_2.so
+account sufficient pam_sober_2.so

--- a/pam-sober-2/src/lib.rs
+++ b/pam-sober-2/src/lib.rs
@@ -1,0 +1,66 @@
+extern crate pam;
+extern crate rand;
+
+use pam::constants::{PamFlag, PamResultCode};
+use pam::items::ItemType::AuthTok;
+use pam::module::{PamHandle, PamHooks};
+use rand::Rng;
+use std::ffi::CStr;
+use std::str::FromStr;
+use pam::pam_try;
+
+struct PamSober;
+pam::pam_hooks!(PamSober);
+
+impl PamHooks for PamSober {
+    // This function performs the task of authenticating the user.
+    fn sm_authenticate(pamh: &mut PamHandle, _args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
+        println!("Let's make sure you're sober enough to perform basic addition! <2>");
+
+        /* TODO: use args to change difficulty ;-)
+        let args: HashMap<&str, &str> = args.iter().map(|s| {
+            let mut parts = s.splitn(2, "=");
+            (parts.next().unwrap(), parts.next().unwrap_or(""))
+        }).collect();
+        */
+
+        // TODO: maybe we can change difficulty base on user?
+        // let user = pam_try!(pamh.get_user(None));
+
+        let mut rng = rand::thread_rng();
+        let a = rng.gen::<u32>() % 100;
+        let b = rng.gen::<u32>() % 100;
+        let math = format!("{} + {} = ", a, b);
+
+        // This println kinda helps debugging since the test script doesn't echo
+        eprintln!("[DEBUG]: {}{}", math, a + b);
+
+        //let password = pam_try!(conv.send(PAM_PROMPT_ECHO_ON, &math));
+        let password = pamh.get_authtok(AuthTok, Some(&math));
+
+        if let Ok(password) = password {
+            let password = password.as_str();
+            eprintln!("[DEBUG]: You entered: {}", password);
+            let answer = pam_try!(u32::from_str(password), PamResultCode::PAM_AUTH_ERR);
+            if answer == a + b {
+                PamResultCode::PAM_SUCCESS
+            } else {
+                println!("Wrong answer provided {} + {} != {}", a, b, answer);
+                PamResultCode::PAM_AUTH_ERR
+            }
+        } else {
+            println!("You failed the PAM sobriety test.");
+            PamResultCode::PAM_AUTH_ERR
+        }
+    }
+
+    fn sm_setcred(_pamh: &mut PamHandle, _args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
+        println!("set credentials");
+        PamResultCode::PAM_SUCCESS
+    }
+
+    fn acct_mgmt(_pamh: &mut PamHandle, _args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
+        println!("account management");
+        PamResultCode::PAM_SUCCESS
+    }
+}

--- a/pam-sober-2/test.c
+++ b/pam-sober-2/test.c
@@ -1,0 +1,54 @@
+#include <security/pam_appl.h>
+#include <security/pam_misc.h>
+#include <stdio.h>
+
+const struct pam_conv conv = {
+	misc_conv,
+	NULL
+};
+
+int main(int argc, char *argv[]) {
+	pam_handle_t* pamh = NULL;
+	int retval;
+	const char* user = "nobody";
+
+	if(argc != 2) {
+		printf("Usage: app [username]\n");
+		exit(1);
+	}
+
+	user = argv[1];
+
+	printf("Initializing PAM ...\n");
+	retval = pam_start("sober-auth-2", user, &conv, &pamh);
+
+	// Are the credentials correct?
+	if (retval == PAM_SUCCESS) {
+		printf("PAM module initialized\n");
+		retval = pam_authenticate(pamh, 0);
+	}
+
+	// Can the accound be used at this time?
+	if (retval == PAM_SUCCESS) {
+		printf("Credentials accepted.\n");
+		retval = pam_acct_mgmt(pamh, 0);
+	}
+
+	// Did everything work?
+	if (retval == PAM_SUCCESS) {
+		printf("Account is valid.\n");
+		printf("Authenticated\n");
+	} else {
+		printf("Not Authenticated\n");
+	}
+
+	// close PAM (end session)
+	if (pam_end(pamh, retval) != PAM_SUCCESS) {
+		pamh = NULL;
+		printf("check_user: failed to release authenticator\n");
+		exit(1);
+	}
+
+	return retval == PAM_SUCCESS ? 0 : 1;
+}
+

--- a/pam/Cargo.toml
+++ b/pam/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "pam-bindings"
 description = "PAM bindings for Rust"
-version = "0.1.1"
+version = "0.1.2"
 authors = [ "Anthony Nowell <anowell@gmail.com>" ]
 repository = "https://github.com/anowell/pam-rs"
 readme = "../README.md"


### PR DESCRIPTION
Hi!

For simple auth scenarios having to bother with a conversation function is overkill in my view.

Therefore I added (by copying from `get_user()`) one essential and missing PAM function, `get_authtok()` (referring to `pam_get_authtok()`) which is able to automatically prompt the user for a (non-echoed) authentication token or password.

As can be seen from the C side at https://web.archive.org/web/20190523222819/https://fedetask.com/write-linux-pam-module/#Authentication_function , `pam_get_user()` and `pam_get_authtok()` are sufficient to write succinct minimal auth libs.

For testing and demo I copied `pam-sober` to `pam-sober-2` and modified it.

Btw the Linux package `pamtester` could be used as a replacement for `test.c` but of course you lost the flexibility of a custom PAM testing application.

Regards