### PR TITLE
Make Conv::send return a SecretVec instead of a &CStr

### DIFF
--- a/pam/Cargo.toml
+++ b/pam/Cargo.toml
@@ -14,3 +14,4 @@ name = "pam"
 
 [dependencies]
 libc = "0.2.97"
+secrets = "1.2"

--- a/pam/src/conv.rs
+++ b/pam/src/conv.rs
@@ -1,5 +1,6 @@
 use libc::{c_char, c_int};
-use std::ffi::{CStr, CString};
+use secrets::SecretVec;
+use std::ffi::CString;
 use std::ptr;
 
 use constants::PamResultCode;
@@ -53,7 +54,7 @@ impl<'a> Conv<'a> {
     /// Note that the user experience will depend on how the client implements
     /// these message styles - and not all applications implement all message
     /// styles.
-    pub fn send(&self, style: PamMessageStyle, msg: &str) -> PamResult<Option<&CStr>> {
+    pub fn send(&self, style: PamMessageStyle, msg: &str) -> PamResult<Option<SecretVec<u8>>> {
         let mut resp_ptr: *const PamResponse = ptr::null();
         let msg_cstr = CString::new(msg).unwrap();
         let msg = PamMessage {
@@ -65,12 +66,27 @@ impl<'a> Conv<'a> {
 
         if PamResultCode::PAM_SUCCESS == ret {
             // PamResponse.resp is null for styles that don't return user input like PAM_TEXT_INFO
-            let response = unsafe { (*resp_ptr).resp };
+            let response: *mut c_char = unsafe { (*resp_ptr).resp as *mut c_char };
             if response.is_null() {
-                Ok(None)
-            } else {
-                Ok(Some(unsafe { CStr::from_ptr(response) }))
+                return Ok(None);
             }
+
+            // SAFETY: response is a non-null, null-terminated C string allocated
+            // by the PAM client application via malloc. We copy it into protected
+            // memory, then zeroize and free the original before returning so that
+            // the plaintext does not linger in unprotected heap memory.
+            let secret = unsafe {
+                let len = libc::strlen(response);
+                let bytes = std::slice::from_raw_parts(response as *const u8, len);
+                let secret = SecretVec::new(len, |out| out.copy_from_slice(bytes));
+                // Zeroize before free so the contents are gone before the
+                // allocator can hand this memory to someone else.
+                std::ptr::write_bytes(response, 0u8, len);
+                libc::free(response as *mut libc::c_void);
+                secret
+            };
+
+            Ok(Some(secret))
         } else {
             Err(ret)
         }

--- a/pam/src/lib.rs
+++ b/pam/src/lib.rs
@@ -25,6 +25,7 @@
 //! to work on other platforms.
 
 extern crate libc;
+extern crate secrets;
 
 pub mod constants;
 pub mod conv;

--- a/pam/src/module.rs
+++ b/pam/src/module.rs
@@ -48,7 +48,7 @@ extern "C" {
 
     fn pam_get_user(
         pamh: *const PamHandle,
-        user: &*mut c_char,
+        user: *mut *const c_char,
         prompt: *const c_char,
     ) -> PamResultCode;
 }
@@ -183,7 +183,7 @@ impl PamHandle {
     ///
     /// Panics if the provided prompt string contains a nul byte
     pub fn get_user(&self, prompt: Option<&str>) -> PamResult<String> {
-        let ptr: *mut c_char = std::ptr::null_mut();
+        let mut ptr: *const c_char = std::ptr::null();
         let prompt_string;
         let c_prompt = match prompt {
             Some(p) => {
@@ -192,7 +192,7 @@ impl PamHandle {
             }
             None => std::ptr::null(),
         };
-        let res = unsafe { pam_get_user(self, &ptr, c_prompt) };
+        let res = unsafe { pam_get_user(self, &mut ptr, c_prompt) };
         if PamResultCode::PAM_SUCCESS == res && !ptr.is_null() {
             let const_ptr = ptr as *const c_char;
             let bytes = unsafe { CStr::from_ptr(const_ptr).to_bytes() };


### PR DESCRIPTION
This fixes a memory leak caused by not freeing response and avoids leaving sensitive information in unprotected memory

WIP; untested