### PR TITLE
Complete licensing metadata configuration (#31)

### DIFF
--- a/pam-http/Cargo.toml
+++ b/pam-http/Cargo.toml
@@ -2,6 +2,8 @@
 name = "pam-http"
 version = "0.1.0"
 authors = ["Anthony Nowell <anowell@gmail.com>"]
+license = "MIT"
+license-file = "../LICENSE"
 
 [lib]
 name = "pam_http"

--- a/pam-sober/Cargo.toml
+++ b/pam-sober/Cargo.toml
@@ -2,6 +2,8 @@
 name = "pam-sober"
 version = "0.1.0"
 authors = ["Anthony Nowell <anowell@gmail.com>"]
+license = "MIT"
+license-file = "../LICENSE"
 
 [lib]
 name = "pam_sober"

--- a/pam/Cargo.toml
+++ b/pam/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/anowell/pam-rs"
 readme = "../README.md"
 keywords = ["pam", "ffi", "linux", "authentication"]
 license = "MIT"
+license-file = "../LICENSE"
 
 [lib]
 name = "pam"


### PR DESCRIPTION
Add licensing metadata to all three crates. Fixes #31 