### PR TITLE
Add integration test suite and harness

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,11 @@ jobs:
       - run: |
           cargo fmt --check
 
+  # It is not possible to run all the tests in a single
+  # `cargo test` invocation. Specifically, `--all-targets`
+  # does not cover doc tests [1].
+  #
+  # [1]: https://github.com/rust-lang/cargo/issues/6669
   test:
     runs-on: ubuntu-latest
     steps:
@@ -30,28 +35,40 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Environment
         run: |
-          sudo apt-get install -y libpam0g-dev
+          sudo apt-get install -y libpam0g-dev bubblewrap pamtester
+          echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Run tests
         run: |
-          # It is not possible to run all the tests in a single
-          # `cargo test` invocation. Specifically, `--all-targets`
-          # does not cover doc tests [1].
-          #
-          # [1]: https://github.com/rust-lang/cargo/issues/6669
-
-          # Run all non-doc tests.
+          # Run tests (debug)
           cargo test \
             --workspace \
             --all-features \
             --verbose \
             --all-targets
 
+          # Run tests (release).
+          cargo test \
+            --workspace \
+            --all-features \
+            --verbose \
+            --all-targets \
+            --release
+      - name: Run doc tests
+        run: |
           # Run all doc tests.
           cargo test \
             --workspace \
             --all-features \
             --verbose \
             --doc
+
+          # Run all doc tests (release).
+          cargo test \
+            --workspace \
+            --all-features \
+            --verbose \
+            --doc \
+            --release
 
   documentation:
     runs-on: ubuntu-latest

--- a/pam/Cargo.toml
+++ b/pam/Cargo.toml
@@ -15,6 +15,9 @@ name = "pam"
 [dependencies]
 libc = "0.2.97"
 
+[dev-dependencies]
+tempfile = "3"
+
 [[example]]
 name = "username"
 crate-type = ["cdylib"]

--- a/pam/Cargo.toml
+++ b/pam/Cargo.toml
@@ -14,3 +14,11 @@ name = "pam"
 
 [dependencies]
 libc = "0.2.97"
+
+[[example]]
+name = "username"
+crate-type = ["cdylib"]
+
+[[example]]
+name = "trivial"
+crate-type = ["cdylib"]

--- a/pam/examples/trivial.rs
+++ b/pam/examples/trivial.rs
@@ -1,0 +1,15 @@
+#[macro_use]
+extern crate pam;
+
+use pam::constants::{PamFlag, PamResultCode};
+use pam::module::{PamHandle, PamHooks};
+use std::ffi::CStr;
+
+struct Trivial;
+pam_hooks!(Trivial);
+
+impl PamHooks for Trivial {
+    fn sm_authenticate(_pamh: &mut PamHandle, _args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
+        PamResultCode::PAM_SUCCESS
+    }
+}

--- a/pam/examples/username.rs
+++ b/pam/examples/username.rs
@@ -1,0 +1,25 @@
+#[macro_use]
+extern crate pam;
+
+use pam::constants::{PamFlag, PamResultCode};
+use pam::module::{PamHandle, PamHooks};
+use std::ffi::CStr;
+
+struct Username;
+pam_hooks!(Username);
+
+impl PamHooks for Username {
+    fn sm_open_session(pamh: &mut PamHandle, _args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
+        let username = match pamh.get_user(None) {
+            Ok(username) => username,
+            Err(e) => {
+                eprintln!("failed to get username, error code: {e:?}");
+                assert!(e != PamResultCode::PAM_SUCCESS);
+                return e;
+            }
+        };
+
+        eprintln!("username: {username}");
+        PamResultCode::PAM_SUCCESS
+    }
+}

--- a/pam/tests/integration/harness.rs
+++ b/pam/tests/integration/harness.rs
@@ -1,0 +1,44 @@
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use std::sync::OnceLock;
+
+pub fn pamtester(example: &str, service_lines: &[&str], user: Option<&str>, op: &str) -> Output {
+    let module = example_module_path(example);
+    let test_dir = tempfile::tempdir().unwrap();
+    let user = user.unwrap_or("user");
+    let svc = "test";
+    let contents: String = service_lines
+        .iter()
+        .map(|line| format!("{line} {}\n", module.display()))
+        .collect();
+    std::fs::write(test_dir.path().join(svc), contents).unwrap();
+    Command::new("bwrap")
+        .args(["--bind", "/", "/"])
+        .args(["--bind", &test_dir.path().to_string_lossy(), "/etc/pam.d"])
+        .args(["--dev", "/dev"])
+        .args(["pamtester", svc, user, op])
+        .output()
+        .unwrap()
+}
+
+fn example_module_path(name: &str) -> PathBuf {
+    static BUILT: OnceLock<()> = OnceLock::new();
+    BUILT.get_or_init(|| {
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+        let release = (!cfg!(debug_assertions)).then_some("--release");
+        let status = Command::new(cargo)
+            .args(["build", "--examples", "--package", "pam-bindings"])
+            .args(release)
+            .status()
+            .unwrap();
+        assert!(status.success());
+    });
+
+    std::env::current_exe()
+        .unwrap()
+        .parent()
+        .and_then(|deps| deps.parent())
+        .unwrap()
+        .join("examples")
+        .join(format!("lib{}.so", name))
+}

--- a/pam/tests/integration/main.rs
+++ b/pam/tests/integration/main.rs
@@ -1,0 +1,4 @@
+mod harness;
+
+mod test_trivial;
+mod test_username;

--- a/pam/tests/integration/test_trivial.rs
+++ b/pam/tests/integration/test_trivial.rs
@@ -1,0 +1,20 @@
+use crate::harness::pamtester;
+
+#[test]
+fn test_trivial_example_module() {
+    let output = pamtester("trivial", &["auth required"], None, "authenticate");
+
+    let expected_stdout = "pamtester: successfully authenticated\n";
+    let expected_stderr = "";
+    let actual_stdout = String::from_utf8_lossy(&output.stdout);
+    let actual_stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "stdout: {} stderr: {}",
+        actual_stdout,
+        actual_stderr
+    );
+    assert_eq!(expected_stdout, actual_stdout);
+    assert_eq!(expected_stderr, actual_stderr);
+}

--- a/pam/tests/integration/test_username.rs
+++ b/pam/tests/integration/test_username.rs
@@ -1,0 +1,26 @@
+use crate::harness::pamtester;
+
+#[test]
+fn test_username_example_module() {
+    let test_username = "testuser";
+    let output = pamtester(
+        "username",
+        &["session required"],
+        Some(test_username),
+        "open_session",
+    );
+
+    let expected_stdout = "pamtester: successfully opened a session\n";
+    let expected_stderr = format!("username: {}\n", test_username);
+    let actual_stdout = String::from_utf8_lossy(&output.stdout);
+    let actual_stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "stdout: {} stderr: {}",
+        actual_stdout,
+        actual_stderr
+    );
+    assert_eq!(expected_stdout, String::from_utf8_lossy(&output.stdout));
+    assert_eq!(expected_stderr, String::from_utf8_lossy(&output.stderr));
+}


### PR DESCRIPTION
> [!NOTE]
> This is meant to fail CI. Specifically, the `cargo test ... --release` step is meant to fail. That's because there's a real bug that we're going to fix over at https://github.com/lvkv/pam-rs/pull/20 (issue: https://github.com/lvkv/pam-rs/issues/16). After rebasing that PR on to `main` and merging, CI should pass.

IMO, most PRs in this repo should come with a proof of correctness, and that's hard to do without a real test suite.

Thus, this PR adds an integration test suite and harness. This is a first take that shells out to `pamtester` and `bwrap` to test PAM realistically using unprivileged namespaces. The `bwrap` bits are highly inspired by prior work on the integration test harness/sandbox for `srv-rs`: https://github.com/deshaw/srv-rs. There's likely room for a Rust-only solution here; the subset of `pamtester` we need could be rewritten in Rust, and we might be able to get away with raw `unshare(2)` calls instead of `bwrap`. For now, I think this is fine.

Regarding the file/project structure: every PAM module being tested needs to be built as a cdylib. The least insane way to do this is to add each module as a crate example. So yes, some examples will also double as test modules. I think that's fine. The tricky bit was ensuring that a `cargo test` actually builds those example modules so that it can actually test them.