### PR TITLE
Chore: Move to Rust edition 2024, fix lints

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,6 +70,26 @@ jobs:
             --doc \
             --release
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - name: Clippy
+        run: |
+          cargo clippy \
+            --workspace \
+            --all-features \
+            --all-targets \
+            -- \
+            --deny clippy::all \
+            --deny clippy::pedantic \
+            --deny clippy::nursery \
+            --deny clippy::cargo \
+            --deny warnings
+
   documentation:
     runs-on: ubuntu-latest
     env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["pam"]
+resolver = "2"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Add `pam-bindings` to your dependencies in Cargo.toml:
 
 ```toml
 [dependencies]
-pam-bindings = "0.1.2"
+pam-bindings = "0.2.0"
 ```
 
 ## Examples

--- a/pam/Cargo.toml
+++ b/pam/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "pam-bindings"
 description = "Simplified PAM module creation in Rust"
-version = "0.1.2"
+version = "0.2.0"
+edition = "2024"
+rust-version = "1.85"
 authors = [
     "Anthony Nowell <anowell@gmail.com>",
     "Lukas Velikov <velikovlukas@gmail.com>",

--- a/pam/examples/quiz.rs
+++ b/pam/examples/quiz.rs
@@ -1,10 +1,7 @@
-#[macro_use]
-extern crate pam;
-extern crate rand;
-
-use pam::constants::{PamFlag, PamResultCode, PAM_PROMPT_ECHO_ON};
+use pam::constants::{PAM_PROMPT_ECHO_ON, PamFlag, PamResultCode};
 use pam::conv::Conv;
 use pam::module::{PamHandle, PamHooks};
+use pam::{pam_hooks, pam_try};
 use rand::Rng;
 use std::ffi::CStr;
 use std::str::FromStr;

--- a/pam/examples/trivial.rs
+++ b/pam/examples/trivial.rs
@@ -1,8 +1,6 @@
-#[macro_use]
-extern crate pam;
-
 use pam::constants::{PamFlag, PamResultCode};
 use pam::module::{PamHandle, PamHooks};
+use pam::pam_hooks;
 use std::ffi::CStr;
 
 struct Trivial;

--- a/pam/examples/username.rs
+++ b/pam/examples/username.rs
@@ -1,8 +1,6 @@
-#[macro_use]
-extern crate pam;
-
 use pam::constants::{PamFlag, PamResultCode};
 use pam::module::{PamHandle, PamHooks};
+use pam::pam_hooks;
 use std::ffi::CStr;
 
 struct Username;

--- a/pam/src/constants.rs
+++ b/pam/src/constants.rs
@@ -28,7 +28,7 @@ pub const PAM_BINARY_PROMPT: PamMessageStyle = 7;
 // The Linux-PAM return values
 // see /usr/include/security/_pam_types.h
 #[allow(non_camel_case_types, dead_code)]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[repr(C)]
 pub enum PamResultCode {
     PAM_SUCCESS = 0,

--- a/pam/src/conv.rs
+++ b/pam/src/conv.rs
@@ -2,10 +2,10 @@ use libc::{c_char, c_int};
 use std::ffi::{CStr, CString};
 use std::ptr;
 
-use constants::PamMessageStyle;
-use constants::PamResultCode;
-use items::Item;
-use module::PamResult;
+use crate::constants::PamMessageStyle;
+use crate::constants::PamResultCode;
+use crate::items::Item;
+use crate::module::PamResult;
 
 #[repr(C)]
 struct PamMessage {
@@ -85,7 +85,7 @@ impl<'a> Item for Conv<'a> {
     }
 
     unsafe fn from_raw(raw: *const Self::Raw) -> Self {
-        Self(&*raw)
+        unsafe { Self(&*raw) }
     }
 
     fn into_raw(self) -> *const Self::Raw {

--- a/pam/src/conv.rs
+++ b/pam/src/conv.rs
@@ -37,22 +37,30 @@ pub struct Inner {
 
 pub struct Conv<'a>(&'a Inner);
 
-impl<'a> Conv<'a> {
+impl Conv<'_> {
     /// Sends a message to the pam client.
     ///
     /// This will typically result in the user seeing a message or a prompt.
     /// There are several message styles available:
     ///
-    /// - PAM_PROMPT_ECHO_OFF
-    /// - PAM_PROMPT_ECHO_ON
-    /// - PAM_ERROR_MSG
-    /// - PAM_TEXT_INFO
-    /// - PAM_RADIO_TYPE
-    /// - PAM_BINARY_PROMPT
+    /// - `PAM_PROMPT_ECHO_OFF`
+    /// - `PAM_PROMPT_ECHO_ON`
+    /// - `PAM_ERROR_MSG`
+    /// - `PAM_TEXT_INFO`
+    /// - `PAM_RADIO_TYPE`
+    /// - `PAM_BINARY_PROMPT`
     ///
     /// Note that the user experience will depend on how the client implements
     /// these message styles - and not all applications implement all message
     /// styles.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying PAM conversation call fails.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the provided message contains a nul byte.
     pub fn send(&self, style: PamMessageStyle, msg: &str) -> PamResult<Option<&CStr>> {
         let mut resp_ptr: *const PamResponse = ptr::null();
         let msg_cstr = CString::new(msg).unwrap();
@@ -77,7 +85,7 @@ impl<'a> Conv<'a> {
     }
 }
 
-impl<'a> Item for Conv<'a> {
+impl Item for Conv<'_> {
     type Raw = Inner;
 
     fn type_id() -> crate::items::ItemType {
@@ -89,6 +97,6 @@ impl<'a> Item for Conv<'a> {
     }
 
     fn into_raw(self) -> *const Self::Raw {
-        self.0 as _
+        std::ptr::from_ref(self.0)
     }
 }

--- a/pam/src/items.rs
+++ b/pam/src/items.rs
@@ -8,7 +8,7 @@ pub enum ItemType {
     Tty = 3,
     /// The remote host name
     RHost = 4,
-    /// The pam_conv structure
+    /// The `pam_conv` structure
     Conv = 5,
     /// The authentication token (password)
     AuthTok = 6,
@@ -24,7 +24,7 @@ pub enum ItemType {
     XDisplay = 11,
     /// X :server authentication data
     XAuthData = 12,
-    /// The type for pam_get_authtok
+    /// The type for `pam_get_authtok`
     AuthTokType = 13,
 }
 

--- a/pam/src/items.rs
+++ b/pam/src/items.rs
@@ -67,7 +67,7 @@ macro_rules! cstr_item {
             }
 
             unsafe fn from_raw(raw: *const Self::Raw) -> Self {
-                Self(std::ffi::CStr::from_ptr(raw))
+                unsafe { Self(std::ffi::CStr::from_ptr(raw)) }
             }
 
             fn into_raw(self) -> *const Self::Raw {

--- a/pam/src/lib.rs
+++ b/pam/src/lib.rs
@@ -36,8 +36,6 @@
 //! The goal of this library is to provide a simple, type-safe API to write
 //! these modules.
 
-extern crate libc;
-
 pub mod constants;
 pub mod conv;
 pub mod items;

--- a/pam/src/macros.rs
+++ b/pam/src/macros.rs
@@ -40,7 +40,7 @@ macro_rules! pam_hooks {
 
             fn extract_argv<'a>(argc: c_int, argv: *const *const c_char) -> Vec<&'a CStr> {
                 (0..argc)
-                    .map(|o| unsafe { CStr::from_ptr(*argv.offset(o as isize) as *const c_char) })
+                    .map(|o| unsafe { CStr::from_ptr(*argv.offset(o as isize)) })
                     .collect()
             }
 

--- a/pam/src/macros.rs
+++ b/pam/src/macros.rs
@@ -7,10 +7,9 @@
 /// Here is full example of a PAM module that would authenticate and authorize everybody:
 ///
 /// ```
-/// #[macro_use] extern crate pam;
-///
 /// use pam::module::{PamHooks, PamHandle};
 /// use pam::constants::{PamResultCode, PamFlag};
+/// use pam::pam_hooks;
 /// use std::ffi::CStr;
 ///
 /// # fn main() {}
@@ -45,7 +44,7 @@ macro_rules! pam_hooks {
                     .collect()
             }
 
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             pub extern "C" fn pam_sm_acct_mgmt(
                 pamh: &mut PamHandle,
                 flags: PamFlag,
@@ -56,7 +55,7 @@ macro_rules! pam_hooks {
                 super::$ident::acct_mgmt(pamh, args, flags)
             }
 
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             pub extern "C" fn pam_sm_authenticate(
                 pamh: &mut PamHandle,
                 flags: PamFlag,
@@ -67,7 +66,7 @@ macro_rules! pam_hooks {
                 super::$ident::sm_authenticate(pamh, args, flags)
             }
 
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             pub extern "C" fn pam_sm_chauthtok(
                 pamh: &mut PamHandle,
                 flags: PamFlag,
@@ -78,7 +77,7 @@ macro_rules! pam_hooks {
                 super::$ident::sm_chauthtok(pamh, args, flags)
             }
 
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             pub extern "C" fn pam_sm_close_session(
                 pamh: &mut PamHandle,
                 flags: PamFlag,
@@ -89,7 +88,7 @@ macro_rules! pam_hooks {
                 super::$ident::sm_close_session(pamh, args, flags)
             }
 
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             pub extern "C" fn pam_sm_open_session(
                 pamh: &mut PamHandle,
                 flags: PamFlag,
@@ -100,7 +99,7 @@ macro_rules! pam_hooks {
                 super::$ident::sm_open_session(pamh, args, flags)
             }
 
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             pub extern "C" fn pam_sm_setcred(
                 pamh: &mut PamHandle,
                 flags: PamFlag,
@@ -132,7 +131,7 @@ macro_rules! pam_try {
 
 #[cfg(test)]
 pub mod test {
-    use module::PamHooks;
+    use crate::module::PamHooks;
 
     struct Foo;
     impl PamHooks for Foo {}

--- a/pam/src/module.rs
+++ b/pam/src/module.rs
@@ -79,7 +79,7 @@ impl PamHandle {
     /// # Safety
     ///
     /// The data stored under the provided key must be of type `T` otherwise the
-    /// behaviour of this funtion is undefined.
+    /// behaviour of this function is undefined.
     pub unsafe fn get_data<'a, T>(&'a self, key: &str) -> PamResult<&'a T> {
         unsafe {
             let c_key = CString::new(key).unwrap();

--- a/pam/src/module.rs
+++ b/pam/src/module.rs
@@ -3,7 +3,7 @@
 use libc::c_char;
 use std::ffi::{CStr, CString};
 
-use constants::{PamFlag, PamResultCode};
+use crate::constants::{PamFlag, PamResultCode};
 
 /// Opaque type, used as a pointer when making pam API calls.
 ///
@@ -16,7 +16,7 @@ pub struct PamHandle {
 }
 
 #[link(name = "pam")]
-extern "C" {
+unsafe extern "C" {
     fn pam_get_data(
         pamh: *const PamHandle,
         module_data_name: *const c_char,
@@ -77,15 +77,17 @@ impl PamHandle {
     /// The data stored under the provided key must be of type `T` otherwise the
     /// behaviour of this funtion is undefined.
     pub unsafe fn get_data<'a, T>(&'a self, key: &str) -> PamResult<&'a T> {
-        let c_key = CString::new(key).unwrap();
-        let mut ptr: *const libc::c_void = std::ptr::null();
-        let res = pam_get_data(self, c_key.as_ptr(), &mut ptr);
-        if PamResultCode::PAM_SUCCESS == res && !ptr.is_null() {
-            let typed_ptr = ptr.cast::<T>();
-            let data: &T = &*typed_ptr;
-            Ok(data)
-        } else {
-            Err(res)
+        unsafe {
+            let c_key = CString::new(key).unwrap();
+            let mut ptr: *const libc::c_void = std::ptr::null();
+            let res = pam_get_data(self, c_key.as_ptr(), &mut ptr);
+            if PamResultCode::PAM_SUCCESS == res && !ptr.is_null() {
+                let typed_ptr = ptr.cast::<T>();
+                let data: &T = &*typed_ptr;
+                Ok(data)
+            } else {
+                Err(res)
+            }
         }
     }
 

--- a/pam/src/module.rs
+++ b/pam/src/module.rs
@@ -81,17 +81,15 @@ impl PamHandle {
     /// The data stored under the provided key must be of type `T` otherwise the
     /// behaviour of this function is undefined.
     pub unsafe fn get_data<'a, T>(&'a self, key: &str) -> PamResult<&'a T> {
-        unsafe {
-            let c_key = CString::new(key).unwrap();
-            let mut ptr: *const libc::c_void = std::ptr::null();
-            let res = pam_get_data(self, c_key.as_ptr(), &mut ptr);
-            if PamResultCode::PAM_SUCCESS == res && !ptr.is_null() {
-                let typed_ptr = ptr.cast::<T>();
-                let data: &T = &*typed_ptr;
-                Ok(data)
-            } else {
-                Err(res)
-            }
+        let c_key = CString::new(key).unwrap();
+        let mut ptr: *const libc::c_void = std::ptr::null();
+        let res = unsafe { pam_get_data(self, c_key.as_ptr(), &mut ptr) };
+        if PamResultCode::PAM_SUCCESS == res && !ptr.is_null() {
+            let typed_ptr = ptr.cast::<T>();
+            let data: &T = unsafe { &*typed_ptr };
+            Ok(data)
+        } else {
+            Err(res)
         }
     }
 
@@ -193,7 +191,7 @@ impl PamHandle {
     ///
     /// Panics if the provided prompt string contains a nul byte
     pub fn get_user(&self, prompt: Option<&str>) -> PamResult<String> {
-        let mut ptr: *const c_char = std::ptr::null_mut();
+        let mut ptr: *const c_char = std::ptr::null();
         let prompt_string = prompt.map(|p| CString::new(p).unwrap());
         let c_prompt = prompt_string
             .as_ref()

--- a/pam/src/module.rs
+++ b/pam/src/module.rs
@@ -72,6 +72,10 @@ impl PamHandle {
     ///
     /// Returns an error if the underlying PAM function call fails.
     ///
+    /// # Panics
+    ///
+    /// Panics if the provided key contains a nul byte.
+    ///
     /// # Safety
     ///
     /// The data stored under the provided key must be of type `T` otherwise the
@@ -100,6 +104,10 @@ impl PamHandle {
     /// # Errors
     ///
     /// Returns an error if the underlying PAM function call fails.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the provided key contains a nul byte.
     pub fn set_data<T>(&self, key: &str, data: Box<T>) -> PamResult<()> {
         let c_key = CString::new(key).unwrap();
         let res = unsafe {
@@ -186,18 +194,13 @@ impl PamHandle {
     /// Panics if the provided prompt string contains a nul byte
     pub fn get_user(&self, prompt: Option<&str>) -> PamResult<String> {
         let mut ptr: *const c_char = std::ptr::null_mut();
-        let prompt_string;
-        let c_prompt = match prompt {
-            Some(p) => {
-                prompt_string = CString::new(p).unwrap();
-                prompt_string.as_ptr()
-            }
-            None => std::ptr::null(),
-        };
+        let prompt_string = prompt.map(|p| CString::new(p).unwrap());
+        let c_prompt = prompt_string
+            .as_ref()
+            .map_or(std::ptr::null(), |s| s.as_ptr());
         let res = unsafe { pam_get_user(self, &mut ptr, c_prompt) };
         if PamResultCode::PAM_SUCCESS == res && !ptr.is_null() {
-            let const_ptr = ptr as *const c_char;
-            let bytes = unsafe { CStr::from_ptr(const_ptr).to_bytes() };
+            let bytes = unsafe { CStr::from_ptr(ptr).to_bytes() };
             String::from_utf8(bytes.to_vec()).map_err(|_| PamResultCode::PAM_CONV_ERR)
         } else {
             Err(res)

--- a/pam/tests/integration/harness.rs
+++ b/pam/tests/integration/harness.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 use std::path::PathBuf;
 use std::process::{Command, Output};
 use std::sync::OnceLock;
@@ -9,7 +10,6 @@ pub fn pamtester(example: &str, service_lines: &[&str], user: Option<&str>, op: 
     let svc = "test";
     let mut contents = String::new();
     for line in service_lines {
-        use std::fmt::Write;
         writeln!(contents, "{line} {}", module.display()).unwrap();
     }
     std::fs::write(test_dir.path().join(svc), contents).unwrap();

--- a/pam/tests/integration/harness.rs
+++ b/pam/tests/integration/harness.rs
@@ -7,10 +7,11 @@ pub fn pamtester(example: &str, service_lines: &[&str], user: Option<&str>, op: 
     let test_dir = tempfile::tempdir().unwrap();
     let user = user.unwrap_or("user");
     let svc = "test";
-    let contents: String = service_lines
-        .iter()
-        .map(|line| format!("{line} {}\n", module.display()))
-        .collect();
+    let mut contents = String::new();
+    for line in service_lines {
+        use std::fmt::Write;
+        writeln!(contents, "{line} {}", module.display()).unwrap();
+    }
     std::fs::write(test_dir.path().join(svc), contents).unwrap();
     Command::new("bwrap")
         .args(["--bind", "/", "/"])
@@ -40,5 +41,5 @@ fn example_module_path(name: &str) -> PathBuf {
         .and_then(|deps| deps.parent())
         .unwrap()
         .join("examples")
-        .join(format!("lib{}.so", name))
+        .join(format!("lib{name}.so"))
 }

--- a/pam/tests/integration/test_trivial.rs
+++ b/pam/tests/integration/test_trivial.rs
@@ -11,9 +11,7 @@ fn test_trivial_example_module() {
 
     assert!(
         output.status.success(),
-        "stdout: {} stderr: {}",
-        actual_stdout,
-        actual_stderr
+        "stdout: {actual_stdout} stderr: {actual_stderr}"
     );
     assert_eq!(expected_stdout, actual_stdout);
     assert_eq!(expected_stderr, actual_stderr);

--- a/pam/tests/integration/test_username.rs
+++ b/pam/tests/integration/test_username.rs
@@ -11,15 +11,13 @@ fn test_username_example_module() {
     );
 
     let expected_stdout = "pamtester: successfully opened a session\n";
-    let expected_stderr = format!("username: {}\n", test_username);
+    let expected_stderr = format!("username: {test_username}\n");
     let actual_stdout = String::from_utf8_lossy(&output.stdout);
     let actual_stderr = String::from_utf8_lossy(&output.stderr);
 
     assert!(
         output.status.success(),
-        "stdout: {} stderr: {}",
-        actual_stdout,
-        actual_stderr
+        "stdout: {actual_stdout} stderr: {actual_stderr}"
     );
     assert_eq!(expected_stdout, String::from_utf8_lossy(&output.stdout));
     assert_eq!(expected_stderr, String::from_utf8_lossy(&output.stderr));


### PR DESCRIPTION
- Move to Rust edition 2024
- Fix all the Clippy lints
- Add a CI job to flag new Clippy lints