### PR TITLE
Fix: Result check, FFI panic guard

### DIFF
--- a/pam/src/macros.rs
+++ b/pam/src/macros.rs
@@ -51,8 +51,10 @@ macro_rules! pam_hooks {
                 argc: c_int,
                 argv: *const *const c_char,
             ) -> PamResultCode {
-                let args = extract_argv(argc, argv);
-                super::$ident::acct_mgmt(pamh, args, flags)
+                $crate::macros::__panic_guard(|| {
+                    let args = extract_argv(argc, argv);
+                    super::$ident::acct_mgmt(pamh, args, flags)
+                })
             }
 
             #[unsafe(no_mangle)]
@@ -62,8 +64,10 @@ macro_rules! pam_hooks {
                 argc: c_int,
                 argv: *const *const c_char,
             ) -> PamResultCode {
-                let args = extract_argv(argc, argv);
-                super::$ident::sm_authenticate(pamh, args, flags)
+                $crate::macros::__panic_guard(|| {
+                    let args = extract_argv(argc, argv);
+                    super::$ident::sm_authenticate(pamh, args, flags)
+                })
             }
 
             #[unsafe(no_mangle)]
@@ -73,8 +77,10 @@ macro_rules! pam_hooks {
                 argc: c_int,
                 argv: *const *const c_char,
             ) -> PamResultCode {
-                let args = extract_argv(argc, argv);
-                super::$ident::sm_chauthtok(pamh, args, flags)
+                $crate::macros::__panic_guard(|| {
+                    let args = extract_argv(argc, argv);
+                    super::$ident::sm_chauthtok(pamh, args, flags)
+                })
             }
 
             #[unsafe(no_mangle)]
@@ -84,8 +90,10 @@ macro_rules! pam_hooks {
                 argc: c_int,
                 argv: *const *const c_char,
             ) -> PamResultCode {
-                let args = extract_argv(argc, argv);
-                super::$ident::sm_close_session(pamh, args, flags)
+                $crate::macros::__panic_guard(|| {
+                    let args = extract_argv(argc, argv);
+                    super::$ident::sm_close_session(pamh, args, flags)
+                })
             }
 
             #[unsafe(no_mangle)]
@@ -95,8 +103,10 @@ macro_rules! pam_hooks {
                 argc: c_int,
                 argv: *const *const c_char,
             ) -> PamResultCode {
-                let args = extract_argv(argc, argv);
-                super::$ident::sm_open_session(pamh, args, flags)
+                $crate::macros::__panic_guard(|| {
+                    let args = extract_argv(argc, argv);
+                    super::$ident::sm_open_session(pamh, args, flags)
+                })
             }
 
             #[unsafe(no_mangle)]
@@ -106,8 +116,10 @@ macro_rules! pam_hooks {
                 argc: c_int,
                 argv: *const *const c_char,
             ) -> PamResultCode {
-                let args = extract_argv(argc, argv);
-                super::$ident::sm_setcred(pamh, args, flags)
+                $crate::macros::__panic_guard(|| {
+                    let args = extract_argv(argc, argv);
+                    super::$ident::sm_setcred(pamh, args, flags)
+                })
             }
         }
     };
@@ -129,12 +141,27 @@ macro_rules! pam_try {
     };
 }
 
+#[doc(hidden)]
+pub fn __panic_guard<F: FnOnce() -> crate::constants::PamResultCode>(
+    f: F,
+) -> crate::constants::PamResultCode {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f))
+        .unwrap_or(crate::constants::PamResultCode::PAM_ABORT)
+}
+
 #[cfg(test)]
 pub mod test {
+    use crate::constants::PamResultCode;
     use crate::module::PamHooks;
 
     struct Foo;
     impl PamHooks for Foo {}
 
     pam_hooks!(Foo);
+
+    #[test]
+    fn panic_returns_error_code() {
+        let code = super::__panic_guard(|| panic!("intentional"));
+        assert_eq!(code, PamResultCode::PAM_ABORT);
+    }
 }

--- a/pam/src/module.rs
+++ b/pam/src/module.rs
@@ -134,20 +134,15 @@ impl PamHandle {
     /// Returns an error if the underlying PAM function call fails.
     pub fn get_item<T: crate::items::Item>(&self) -> PamResult<Option<T>> {
         let mut ptr: *const libc::c_void = std::ptr::null();
-        let (res, item) = unsafe {
-            let r = pam_get_item(self, T::type_id(), &mut ptr);
-            let typed_ptr = ptr.cast::<T::Raw>();
-            let t = if typed_ptr.is_null() {
-                None
-            } else {
-                Some(T::from_raw(typed_ptr))
-            };
-            (r, t)
-        };
-        if PamResultCode::PAM_SUCCESS == res {
-            Ok(item)
+        let res = unsafe { pam_get_item(self, T::type_id(), &mut ptr) };
+        if PamResultCode::PAM_SUCCESS != res {
+            return Err(res);
+        }
+        let typed_ptr = ptr.cast::<T::Raw>();
+        if typed_ptr.is_null() {
+            Ok(None)
         } else {
-            Err(res)
+            Ok(Some(unsafe { T::from_raw(typed_ptr) }))
         }
     }
 


### PR DESCRIPTION
This closes #22 and closes #23 by checking a result in module::get_item and adding an FFI panic guard respectively.