### PR TITLE
Build: Prepare v0.2.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Add `pam-bindings` to your dependencies in Cargo.toml:
 
 ```toml
 [dependencies]
-pam-bindings = "0.2.0"
+pam-bindings = "0.2.1"
 ```
 
 ## Examples

--- a/pam/Cargo.toml
+++ b/pam/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pam-bindings"
 description = "Simplified PAM module creation in Rust"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.85"
 authors = [
@@ -11,7 +11,7 @@ authors = [
 repository = "https://github.com/lvkv/pam-rs"
 homepage = "https://github.com/lvkv/pam-rs"
 readme = "../README.md"
-license = "MIT"
+license-file = "../LICENSE"
 keywords = ["pam", "ffi", "linux", "authentication"]
 categories = ["authentication", "security", "os", "external-ffi-bindings"]
 


### PR DESCRIPTION
Skipping over releasing v0.2.0 because of the pace of updates.

## What's Changed

* Docs: Update readme template, examples, drop HTTP by @lvkv in https://github.com/lvkv/pam-rs/pull/36
* Chore: Move to Rust edition 2024, fix lints by @lvkv in https://github.com/lvkv/pam-rs/pull/37
* Fix: Result check, FFI panic guard by @lvkv in https://github.com/lvkv/pam-rs/pull/38
* Fix: Use CString instead of CStr, update tests by @lvkv in https://github.com/lvkv/pam-rs/pull/39
* Make library panic-free by @lvkv in https://github.com/lvkv/pam-rs/pull/40
* Fix: Error on invalid argc, argv by @lvkv in https://github.com/lvkv/pam-rs/pull/41
* Fix: PAM handle thread safety by @lvkv in https://github.com/lvkv/pam-rs/pull/42
* Fix missing license files in published crates by @musicinmybrain in https://github.com/lvkv/pam-rs/pull/18
* Chore: Clean up old example module dirs by @lvkv in https://github.com/lvkv/pam-rs/pull/43