### PR TITLE
Fix: Tie item lifetime to PAM handle lifetime

### DIFF
--- a/pam/src/conv.rs
+++ b/pam/src/conv.rs
@@ -89,7 +89,7 @@ impl Conv<'_> {
     }
 }
 
-impl Item for Conv<'_> {
+impl<'a> Item<'a> for Conv<'a> {
     type Raw = Inner;
 
     fn type_id() -> crate::items::ItemType {

--- a/pam/src/items.rs
+++ b/pam/src/items.rs
@@ -28,8 +28,8 @@ pub enum ItemType {
     AuthTokType = 13,
 }
 
-// A type that can be requested by `pam::Handle::get_item`.
-pub trait Item {
+/// A type that can be requested by [`crate::module::PamHandle::get_item`].
+pub trait Item<'a> {
     /// The `repr(C)` type that is returned (by pointer) by the underlying `pam_get_item` function.
     type Raw;
 
@@ -40,7 +40,7 @@ pub trait Item {
     ///
     /// # Safety
     ///
-    /// This function can assume the pointer is a valid pointer to a `Self::Raw` instance.
+    /// This function can assume the pointer is a valid pointer to a `Self::Raw` instance valid for `'a`.
     unsafe fn from_raw(raw: *const Self::Raw) -> Self;
 
     /// The function to convert from this wrapper type to a C-compatible pointer.
@@ -59,7 +59,7 @@ macro_rules! cstr_item {
             }
         }
 
-        impl<'s> Item for $name<'s> {
+        impl<'s> Item<'s> for $name<'s> {
             type Raw = libc::c_char;
 
             fn type_id() -> ItemType {

--- a/pam/src/module.rs
+++ b/pam/src/module.rs
@@ -135,7 +135,7 @@ impl PamHandle {
     /// # Errors
     ///
     /// Returns an error if the underlying PAM function call fails.
-    pub fn get_item<T: crate::items::Item>(&self) -> PamResult<Option<T>> {
+    pub fn get_item<'a, T: crate::items::Item<'a>>(&'a self) -> PamResult<Option<T>> {
         let mut ptr: *const libc::c_void = std::ptr::null();
         let res = unsafe { pam_get_item(self, T::type_id(), &mut ptr) };
         if PamResultCode::PAM_SUCCESS != res {
@@ -160,11 +160,7 @@ impl PamHandle {
     /// # Errors
     ///
     /// Returns an error if the underlying PAM function call fails.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the provided item key contains a nul byte
-    pub fn set_item_str<T: crate::items::Item>(&mut self, item: T) -> PamResult<()> {
+    pub fn set_item_str<'a, T: crate::items::Item<'a>>(&mut self, item: T) -> PamResult<()> {
         let res =
             unsafe { pam_set_item(self, T::type_id(), item.into_raw().cast::<libc::c_void>()) };
         if PamResultCode::PAM_SUCCESS == res {


### PR DESCRIPTION
Pointers from `pam_get_item` must be to the lifetime of the PAM handle that originated them. From: https://man7.org/linux/man-pages/man3/pam_get_item.3.html:

> The pam_get_item function allows applications and PAM service
       modules to access and retrieve PAM information of item_type. Upon
       successful return, item contains a pointer to the value of the
       corresponding item. Note, this is a pointer to the actual data and
       should not be free()'ed or over-written!
