### PR TITLE
Fix: Module error handling, cleanup callback panic handling

### DIFF
--- a/pam/src/module.rs
+++ b/pam/src/module.rs
@@ -81,6 +81,7 @@ impl PamHandle {
     ///
     /// - [`PamResultCode`] if the lookup itself fails.
     /// - [`PamResultCode::PAM_BUF_ERR`] if the key string bytes contain an internal 0 byte.
+    /// - [`PamResultCode::PAM_SYSTEM_ERR`] if PAM reports success but yields a null pointer.
     ///
     /// # Safety
     ///
@@ -90,13 +91,15 @@ impl PamHandle {
         let c_key = CString::new(key).map_err(|_| PamResultCode::PAM_BUF_ERR)?;
         let mut ptr: *const libc::c_void = std::ptr::null();
         let res = PamResultCode::from_raw(unsafe { pam_get_data(self, c_key.as_ptr(), &mut ptr) });
-        if PamResultCode::PAM_SUCCESS == res && !ptr.is_null() {
-            let typed_ptr = ptr.cast::<T>();
-            let data: &T = unsafe { &*typed_ptr };
-            Ok(data)
-        } else {
-            Err(res)
+        if PamResultCode::PAM_SUCCESS != res {
+            return Err(res);
         }
+        if ptr.is_null() {
+            return Err(PamResultCode::PAM_SYSTEM_ERR);
+        }
+        let typed_ptr = ptr.cast::<T>();
+        let data: &T = unsafe { &*typed_ptr };
+        Ok(data)
     }
 
     /// Stores a value that can be retrieved later with `get_data`.  The value lives
@@ -184,6 +187,8 @@ impl PamHandle {
     ///
     /// - [`PamResultCode`] if the lookup itself fails.
     /// - [`PamResultCode::PAM_BUF_ERR`] if the prompt string contains a 0 byte.
+    /// - [`PamResultCode::PAM_SYSTEM_ERR`] if PAM reports success but yields a null pointer.
+    /// - [`PamResultCode::PAM_SYSTEM_ERR`] if the returned username is not valid UTF-8.
     pub fn get_user(&self, prompt: Option<&str>) -> PamResult<String> {
         let mut ptr: *const c_char = std::ptr::null();
         let prompt_string = prompt
@@ -194,12 +199,14 @@ impl PamHandle {
             .as_ref()
             .map_or(std::ptr::null(), |s| s.as_ptr());
         let res = PamResultCode::from_raw(unsafe { pam_get_user(self, &mut ptr, c_prompt) });
-        if PamResultCode::PAM_SUCCESS == res && !ptr.is_null() {
-            let bytes = unsafe { CStr::from_ptr(ptr).to_bytes() };
-            String::from_utf8(bytes.to_vec()).map_err(|_| PamResultCode::PAM_CONV_ERR)
-        } else {
-            Err(res)
+        if PamResultCode::PAM_SUCCESS != res {
+            return Err(res);
         }
+        if ptr.is_null() {
+            return Err(PamResultCode::PAM_SYSTEM_ERR);
+        }
+        let bytes = unsafe { CStr::from_ptr(ptr).to_bytes() };
+        String::from_utf8(bytes.to_vec()).map_err(|_| PamResultCode::PAM_SYSTEM_ERR)
     }
 }
 

--- a/pam/src/module.rs
+++ b/pam/src/module.rs
@@ -63,8 +63,17 @@ unsafe extern "C" {
 }
 
 extern "C" fn cleanup<T>(_: *const PamHandle, c_data: *mut libc::c_void, _: c_int) {
-    unsafe {
+    // A panic on Drop for T must not unwind across the C boundary
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
         let _data: Box<T> = Box::from_raw(c_data.cast::<T>());
+    }));
+    // Dropping the above result can itself panic, and is surprisingly difficult to get right.
+    // From the docs for catch_unwind:
+    // > Finally, be careful in how you drop the result of this function. If it is Err, it contains the panic payload, and dropping that may in turn panic!
+    // See: https://internals.rust-lang.org/t/some-thoughts-on-a-less-slippery-catch-unwind/16902/4
+    if let Err(payload) = result {
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| drop(payload)))
+            .map_err(std::mem::forget);
     }
 }
 
@@ -258,5 +267,40 @@ pub trait PamHooks {
     /// authenticated but before a session has been established.
     fn sm_setcred(pamh: &mut PamHandle, args: Vec<&CStr>, flags: PamFlag) -> PamResultCode {
         PamResultCode::PAM_IGNORE
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cleanup_handles_drop_panics() {
+        // Scenario 1
+        // T::drop panics
+        {
+            struct Bomb;
+            impl Drop for Bomb {
+                fn drop(&mut self) {
+                    panic!();
+                }
+            }
+            let ptr = Box::into_raw(Box::new(Bomb)).cast::<libc::c_void>();
+            cleanup::<Bomb>(std::ptr::null(), ptr, 0);
+        }
+
+        // Scenario 2
+        // Every payload's Drop spawns another panic
+        {
+            struct BombRecursive;
+            impl Drop for BombRecursive {
+                fn drop(&mut self) {
+                    std::panic::panic_any(Self);
+                }
+            }
+            let ptr = Box::into_raw(Box::new(BombRecursive)).cast::<libc::c_void>();
+            cleanup::<BombRecursive>(std::ptr::null(), ptr, 0);
+        }
     }
 }


### PR DESCRIPTION
Two module-related fixes:

1. The current code can technically return `Err(PAM_SUCCESS)` if the library returns a `PAM_SUCCESS` code and simultaneously hands back a null pointer (for whatever reason). This would lead to an outcome not unlike https://github.com/lvkv/pam-rs/issues/16#issuecomment-3693665220 ) (which looked like: `failed to get username, error code: PAM_SUCCESS`). This PR updates the code to return an `PAM_SYSTEM_ERR` in this edge case. Also update the "string isn't valid UTF-8" error code to `PAM_SYSTEM_ERR` and documents it instead of the previously undocumented `PAM_CONV_ERR`.
2. The Rust-written cleanup callback we pass over the FFI boundary to PAM can panic, which is Not Good. This updates the callback (which is otherwise quite simple) to essentially avoid panics at all costs. This is surprisingly difficult to get right (drops can panic... and the thing that catches the panic can panic... and if all else fails, just forget/leak), and I've added some hopefully helpful comments and a test around the actual fix. See:
    a. https://internals.rust-lang.org/t/some-thoughts-on-a-less-slippery-catch-unwind/16902/4
    b. https://github.com/rust-lang/rust/issues/86027  