### PR TITLE
Zeroize potentially sensitive bytes

### DIFF
--- a/pam/Cargo.toml
+++ b/pam/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/lib.rs"
 
 [dependencies]
 libc = "0.2.97"
+zeroize = "1.8.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/pam/examples/quiz.rs
+++ b/pam/examples/quiz.rs
@@ -21,7 +21,7 @@ impl PamHooks for Quiz {
             return PamResultCode::PAM_CONV_ERR;
         };
 
-        let response = pam_try!(response.to_str(), PamResultCode::PAM_AUTH_ERR);
+        let response = pam_try!(response.as_str(), PamResultCode::PAM_AUTH_ERR);
         let answer = pam_try!(u32::from_str(response), PamResultCode::PAM_AUTH_ERR);
 
         if answer == 5 {

--- a/pam/src/conv.rs
+++ b/pam/src/conv.rs
@@ -6,6 +6,7 @@ use crate::constants::PamMessageStyle;
 use crate::constants::PamResultCode;
 use crate::items::Item;
 use crate::module::PamResult;
+use crate::secret::{SecretBytes, zeroize_raw};
 
 #[repr(C)]
 struct PamMessage {
@@ -56,13 +57,18 @@ impl Conv<'_> {
     /// these message styles - and not all applications implement all message
     /// styles.
     ///
+    /// # Returns
+    ///
+    /// - [`SecretBytes`] carrying the user's reply.
+    /// - [`None`] if the conversation returns no input.
+    ///
     /// # Errors
     ///
     /// - [`PamResultCode`] if the conversation call fails.
     /// - [`PamResultCode::PAM_BUF_ERR`] if the message string bytes contain an internal 0 byte.
     /// - [`PamResultCode::PAM_CONV_ERR`] if no conversation function was registered.
-    /// - [`PamResultCode::PAM_CONV_ERR`] if the conversation succeeds but yields a null response.
-    pub fn send(&self, style: PamMessageStyle, msg: &str) -> PamResult<Option<CString>> {
+    /// - [`PamResultCode::PAM_CONV_ERR`] if the conversation succeeds but returns a null response pointer.
+    pub fn send(&self, style: PamMessageStyle, msg: &str) -> PamResult<Option<SecretBytes>> {
         let Some(conv_fn) = self.0.conv else {
             return Err(PamResultCode::PAM_CONV_ERR);
         };
@@ -93,9 +99,12 @@ impl Conv<'_> {
         let response = if resp_field.is_null() {
             None
         } else {
-            let owned = unsafe { CStr::from_ptr(resp_field) }.to_owned();
+            // Copy into a buffer that will be zeroed out when dropped
+            let bytes = unsafe { CStr::from_ptr(resp_field) }.to_bytes().to_vec();
+            // Zero out the libc buffer before freeing it
+            unsafe { zeroize_raw(resp_field.cast(), bytes.len()) };
             unsafe { libc::free(resp_field.cast()) };
-            Some(owned)
+            Some(SecretBytes::new(bytes))
         };
         unsafe { libc::free(resp_ptr.cast()) };
         Ok(response)

--- a/pam/src/items.rs
+++ b/pam/src/items.rs
@@ -82,7 +82,56 @@ cstr_item!(User);
 cstr_item!(Tty);
 cstr_item!(RHost);
 // Conv
-cstr_item!(AuthTok);
-cstr_item!(OldAuthTok);
 cstr_item!(RUser);
 cstr_item!(UserPrompt);
+
+macro_rules! secret_cstr_item {
+    ($name:ident, $doc:expr) => {
+        #[doc = $doc]
+        ///
+        /// Borrow into PAM-owned memory.
+        pub struct $name<'s>(&'s std::ffi::CStr);
+
+        impl<'s> $name<'s> {
+            /// Borrow the raw secret bytes without a null terminator.
+            #[must_use]
+            #[allow(clippy::missing_const_for_fn)]
+            pub fn as_bytes(&self) -> &[u8] {
+                self.0.to_bytes()
+            }
+
+            /// Return an owned copy of the bytes.
+            #[must_use]
+            pub fn to_owned_secret(&self) -> $crate::secret::SecretBytes {
+                $crate::secret::SecretBytes::new(self.0.to_bytes().to_vec())
+            }
+        }
+
+        impl std::fmt::Debug for $name<'_> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_tuple(stringify!($name))
+                    .field(&"[redacted]")
+                    .finish()
+            }
+        }
+
+        impl<'s> Item<'s> for $name<'s> {
+            type Raw = libc::c_char;
+
+            fn type_id() -> ItemType {
+                ItemType::$name
+            }
+
+            unsafe fn from_raw(raw: *const Self::Raw) -> Self {
+                unsafe { Self(std::ffi::CStr::from_ptr(raw)) }
+            }
+
+            fn into_raw(self) -> *const Self::Raw {
+                self.0.as_ptr()
+            }
+        }
+    };
+}
+
+secret_cstr_item!(AuthTok, "The user's current authentication token.");
+secret_cstr_item!(OldAuthTok, "The user's previous authentication token.");

--- a/pam/src/items.rs
+++ b/pam/src/items.rs
@@ -89,7 +89,7 @@ macro_rules! secret_cstr_item {
     ($name:ident, $doc:expr) => {
         #[doc = $doc]
         ///
-        /// Borrow into PAM-owned memory.
+        /// Borrow from PAM-owned memory.
         pub struct $name<'s>(&'s std::ffi::CStr);
 
         impl<'s> $name<'s> {

--- a/pam/src/lib.rs
+++ b/pam/src/lib.rs
@@ -50,3 +50,4 @@ pub mod items;
 #[doc(hidden)]
 pub mod macros;
 pub mod module;
+pub mod secret;

--- a/pam/src/secret.rs
+++ b/pam/src/secret.rs
@@ -1,0 +1,74 @@
+//! Owned, zeroize-on-drop containers for sensitive byte material.
+
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+/// An owned byte buffer that is zeroed out when dropped.
+/// Returned wherever this crate hands a secret back to the caller.
+pub struct SecretBytes(Vec<u8>);
+
+impl Zeroize for SecretBytes {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl ZeroizeOnDrop for SecretBytes {}
+
+impl Drop for SecretBytes {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl SecretBytes {
+    /// Create a new [`SecretBytes`] from a [`Vec<u8>`].
+    pub(crate) const fn new(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the bytes as a slice.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Borrow the bytes as a string slice.
+    ///
+    /// # Errors
+    ///
+    /// - [`std::str::Utf8Error`] if the bytes are not valid UTF-8.
+    pub fn as_str(&self) -> Result<&str, std::str::Utf8Error> {
+        std::str::from_utf8(&self.0)
+    }
+
+    /// Return the number of bytes held.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Return `true` if no bytes are held.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl std::fmt::Debug for SecretBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("SecretBytes").field(&"[redacted]").finish()
+    }
+}
+
+/// Zeroize `len` bytes at `ptr`.
+///
+/// Used for libc allocations handed back by PAM.
+///
+/// # Safety
+///
+/// - `ptr` must be non-null and valid for writes of `len` bytes.
+/// - The caller must have exclusive access to the memory for the duration of the call.
+pub(crate) unsafe fn zeroize_raw(ptr: *mut u8, len: usize) {
+    let slice = unsafe { std::slice::from_raw_parts_mut(ptr, len) };
+    slice.zeroize();
+}


### PR DESCRIPTION
Some points in this codebase handle potential secrets. These need debug impls that don't leak and, ideally, bytes that are zeroized on drop or before being libc free'd (context-dependent). This PR:

- Adds a "secret bytes" type that wraps potentially sensitive bytes and zeroizes on drop
- Returns this type whenever the value is likely to contain a potential secret 
- Internally, zeroizes PAM/libc-allocated buffers before freeing them
- Redacts debug implementations where appropriate  

This required writing a new secret_cstr_item macro, modeled after the existing cstr_item macro, to handle the AuthTok and OldAuthTok types.