### PR TITLE
Fix/CI: Handle potential null, add Miri to CI 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,7 @@ jobs:
             --release
       - name: Run doc tests
         run: |
-          # Run all doc tests.
+          # Run all doc tests (debug).
           cargo test \
             --workspace \
             --all-features \
@@ -69,6 +69,22 @@ jobs:
             --verbose \
             --doc \
             --release
+
+  miri:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+      - name: Run Miri
+        run: |
+          # Exclude integration tests that actually call into PAM.
+          cargo miri test \
+            --workspace \
+            --all-features \
+            --verbose \
+            --lib
 
   lint:
     runs-on: ubuntu-latest

--- a/pam/src/module.rs
+++ b/pam/src/module.rs
@@ -63,6 +63,10 @@ unsafe extern "C" {
 }
 
 extern "C" fn cleanup<T>(_: *const PamHandle, c_data: *mut libc::c_void, _: c_int) {
+    // PAM should never hand us null here, but Box::from_raw(null) would be UB.
+    if c_data.is_null() {
+        return;
+    }
     // A panic on Drop for T must not unwind across the C boundary
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
         let _data: Box<T> = Box::from_raw(c_data.cast::<T>());
@@ -276,7 +280,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cleanup_handles_drop_panics() {
+    fn cleanup_disaster_scenarios() {
+        // PAM is not expected to call cleanup with null data, but we must handle it regardless
+        cleanup::<String>(std::ptr::null(), std::ptr::null_mut(), 0);
+
         // Scenario 1
         // T::drop panics
         {

--- a/pam/src/module.rs
+++ b/pam/src/module.rs
@@ -63,7 +63,7 @@ unsafe extern "C" {
 }
 
 extern "C" fn cleanup<T>(_: *const PamHandle, c_data: *mut libc::c_void, _: c_int) {
-    // PAM should never hand us null here, but Box::from_raw(null) would be UB.
+    // Defensive null check, PAM shouldn't normally hand us null here
     if c_data.is_null() {
         return;
     }


### PR DESCRIPTION
The data argument supplied to the cleanup callback we hand to PAM can technically be null. This shouldn't normally happen (given the whole point of the cleanup callback), but the possibility needs to be handled regardless. This was actually caught by running miri on the test update included in this PR:

```rust
test module::tests::cleanup_disaster_scenarios ... error: Undefined Behavior: constructing invalid value: encountered 0, but expected something greater or equal to 1:
    |
90  |         unsafe { Unique { pointer: NonNull::new_unchecked(ptr), _marker: PhantomData } }
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1
    |
```

Not unrelatedly, this PR also updates CI to add a miri test job. 