### PR TITLE
Macros, Conv: Handle edge cases, refactor macros

### DIFF
--- a/pam/src/constants.rs
+++ b/pam/src/constants.rs
@@ -21,9 +21,11 @@ pub const PAM_PROMPT_ECHO_OFF: PamMessageStyle = 1;
 pub const PAM_PROMPT_ECHO_ON: PamMessageStyle = 2;
 pub const PAM_ERROR_MSG: PamMessageStyle = 3;
 pub const PAM_TEXT_INFO: PamMessageStyle = 4;
-/// yes/no/maybe conditionals
 pub const PAM_RADIO_TYPE: PamMessageStyle = 5;
-pub const PAM_BINARY_PROMPT: PamMessageStyle = 7;
+// Intentionally not public: we don't yet have a send API for this style.
+// Kept to document the reserved value and to exercise rejection in tests.
+#[allow(dead_code)]
+pub(crate) const PAM_BINARY_PROMPT: PamMessageStyle = 7;
 
 // The Linux-PAM return values
 // see /usr/include/security/_pam_types.h

--- a/pam/src/constants.rs
+++ b/pam/src/constants.rs
@@ -23,7 +23,6 @@ pub const PAM_ERROR_MSG: PamMessageStyle = 3;
 pub const PAM_TEXT_INFO: PamMessageStyle = 4;
 pub const PAM_RADIO_TYPE: PamMessageStyle = 5;
 // Intentionally not public: we don't yet have a send API for this style.
-// Kept to document the reserved value and to exercise rejection in tests.
 #[allow(dead_code)]
 pub(crate) const PAM_BINARY_PROMPT: PamMessageStyle = 7;
 

--- a/pam/src/conv.rs
+++ b/pam/src/conv.rs
@@ -189,7 +189,7 @@ mod tests {
                     conv: None,
                     appdata_ptr: ptr::null_mut(),
                 },
-                style: PAM_BINARY_PROMPT,
+                style: PAM_PROMPT_ECHO_OFF,
                 expected: Err(PamResultCode::PAM_CONV_ERR),
                 message: "",
             },

--- a/pam/src/conv.rs
+++ b/pam/src/conv.rs
@@ -4,6 +4,9 @@ use std::ptr;
 
 use crate::constants::PamMessageStyle;
 use crate::constants::PamResultCode;
+use crate::constants::{
+    PAM_ERROR_MSG, PAM_PROMPT_ECHO_OFF, PAM_PROMPT_ECHO_ON, PAM_RADIO_TYPE, PAM_TEXT_INFO,
+};
 use crate::items::Item;
 use crate::module::PamResult;
 use crate::secret::{SecretBytes, zeroize_raw};
@@ -51,7 +54,6 @@ impl Conv<'_> {
     /// - `PAM_ERROR_MSG`
     /// - `PAM_TEXT_INFO`
     /// - `PAM_RADIO_TYPE`
-    /// - `PAM_BINARY_PROMPT`
     ///
     /// Note that the user experience will depend on how the client implements
     /// these message styles - and not all applications implement all message
@@ -68,7 +70,14 @@ impl Conv<'_> {
     /// - [`PamResultCode::PAM_BUF_ERR`] if the message string bytes contain an internal 0 byte.
     /// - [`PamResultCode::PAM_CONV_ERR`] if no conversation function was registered.
     /// - [`PamResultCode::PAM_CONV_ERR`] if the conversation succeeds but returns a null response pointer.
+    /// - [`PamResultCode::PAM_CONV_ERR`] if `style` is unsupported.
     pub fn send(&self, style: PamMessageStyle, msg: &str) -> PamResult<Option<SecretBytes>> {
+        // Only string-based styles are supported; binary prompts and unknown styles are rejected.
+        match style {
+            PAM_PROMPT_ECHO_OFF | PAM_PROMPT_ECHO_ON | PAM_ERROR_MSG | PAM_TEXT_INFO
+            | PAM_RADIO_TYPE => {}
+            _ => return Err(PamResultCode::PAM_CONV_ERR),
+        }
         let Some(conv_fn) = self.0.conv else {
             return Err(PamResultCode::PAM_CONV_ERR);
         };
@@ -124,5 +133,81 @@ impl<'a> Item<'a> for Conv<'a> {
 
     fn into_raw(self) -> *const Self::Raw {
         std::ptr::from_ref(self.0)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::constants::PAM_BINARY_PROMPT;
+
+    /// A conversation function that should never run used for testing.
+    extern "C" fn unreachable_conv(
+        _: c_int,
+        _: *const *const PamMessage,
+        _: *mut *mut PamResponse,
+        _: *mut libc::c_void,
+    ) -> c_int {
+        panic!("this conversation function shouldn't run");
+    }
+
+    /// A test case for the [`Conv::send`] method.
+    struct SendTestCase {
+        inner: Inner,
+        style: PamMessageStyle,
+        expected: PamResult<Option<SecretBytes>>,
+        message: &'static str,
+    }
+
+    #[test]
+    fn send_error_cases() {
+        let test_cases: Vec<SendTestCase> = vec![
+            // Error on binary prompt
+            SendTestCase {
+                inner: Inner {
+                    conv: Some(unreachable_conv),
+                    appdata_ptr: ptr::null_mut(),
+                },
+                style: PAM_BINARY_PROMPT,
+                expected: Err(PamResultCode::PAM_CONV_ERR),
+                message: "",
+            },
+            // Error on unknown style
+            SendTestCase {
+                inner: Inner {
+                    conv: Some(unreachable_conv),
+                    appdata_ptr: ptr::null_mut(),
+                },
+                style: c_int::MIN,
+                expected: Err(PamResultCode::PAM_CONV_ERR),
+                message: "",
+            },
+            // Error if no conversation function is provided
+            SendTestCase {
+                inner: Inner {
+                    conv: None,
+                    appdata_ptr: ptr::null_mut(),
+                },
+                style: PAM_BINARY_PROMPT,
+                expected: Err(PamResultCode::PAM_CONV_ERR),
+                message: "",
+            },
+            // Error if message contains internal 0 byte
+            SendTestCase {
+                inner: Inner {
+                    conv: Some(unreachable_conv),
+                    appdata_ptr: ptr::null_mut(),
+                },
+                style: PAM_PROMPT_ECHO_OFF,
+                expected: Err(PamResultCode::PAM_BUF_ERR),
+                message: "PAM is fun\0sometimes",
+            },
+        ];
+
+        for test_case in test_cases {
+            let actual = Conv(&test_case.inner).send(test_case.style, test_case.message);
+            assert_eq!(test_case.expected.unwrap_err(), actual.unwrap_err());
+        }
     }
 }

--- a/pam/src/macros.rs
+++ b/pam/src/macros.rs
@@ -52,12 +52,11 @@ macro_rules! pam_hooks {
                 argc: c_int,
                 argv: *const *const c_char,
             ) -> PamResultCode {
-                $crate::macros::__panic_guard(|| {
-                    match unsafe { $crate::macros::extract_argv(argc, argv) } {
-                        Ok(args) => super::$ident::acct_mgmt(pamh, args, flags),
-                        Err(e) => e,
-                    }
-                })
+                unsafe {
+                    $crate::macros::invoke_hook(argc, argv, |args| {
+                        super::$ident::acct_mgmt(pamh, args, flags)
+                    })
+                }
             }
 
             #[unsafe(no_mangle)]
@@ -67,12 +66,11 @@ macro_rules! pam_hooks {
                 argc: c_int,
                 argv: *const *const c_char,
             ) -> PamResultCode {
-                $crate::macros::__panic_guard(|| {
-                    match unsafe { $crate::macros::extract_argv(argc, argv) } {
-                        Ok(args) => super::$ident::sm_authenticate(pamh, args, flags),
-                        Err(e) => e,
-                    }
-                })
+                unsafe {
+                    $crate::macros::invoke_hook(argc, argv, |args| {
+                        super::$ident::sm_authenticate(pamh, args, flags)
+                    })
+                }
             }
 
             #[unsafe(no_mangle)]
@@ -82,12 +80,11 @@ macro_rules! pam_hooks {
                 argc: c_int,
                 argv: *const *const c_char,
             ) -> PamResultCode {
-                $crate::macros::__panic_guard(|| {
-                    match unsafe { $crate::macros::extract_argv(argc, argv) } {
-                        Ok(args) => super::$ident::sm_chauthtok(pamh, args, flags),
-                        Err(e) => e,
-                    }
-                })
+                unsafe {
+                    $crate::macros::invoke_hook(argc, argv, |args| {
+                        super::$ident::sm_chauthtok(pamh, args, flags)
+                    })
+                }
             }
 
             #[unsafe(no_mangle)]
@@ -97,12 +94,11 @@ macro_rules! pam_hooks {
                 argc: c_int,
                 argv: *const *const c_char,
             ) -> PamResultCode {
-                $crate::macros::__panic_guard(|| {
-                    match unsafe { $crate::macros::extract_argv(argc, argv) } {
-                        Ok(args) => super::$ident::sm_close_session(pamh, args, flags),
-                        Err(e) => e,
-                    }
-                })
+                unsafe {
+                    $crate::macros::invoke_hook(argc, argv, |args| {
+                        super::$ident::sm_close_session(pamh, args, flags)
+                    })
+                }
             }
 
             #[unsafe(no_mangle)]
@@ -112,12 +108,11 @@ macro_rules! pam_hooks {
                 argc: c_int,
                 argv: *const *const c_char,
             ) -> PamResultCode {
-                $crate::macros::__panic_guard(|| {
-                    match unsafe { $crate::macros::extract_argv(argc, argv) } {
-                        Ok(args) => super::$ident::sm_open_session(pamh, args, flags),
-                        Err(e) => e,
-                    }
-                })
+                unsafe {
+                    $crate::macros::invoke_hook(argc, argv, |args| {
+                        super::$ident::sm_open_session(pamh, args, flags)
+                    })
+                }
             }
 
             #[unsafe(no_mangle)]
@@ -127,12 +122,11 @@ macro_rules! pam_hooks {
                 argc: c_int,
                 argv: *const *const c_char,
             ) -> PamResultCode {
-                $crate::macros::__panic_guard(|| {
-                    match unsafe { $crate::macros::extract_argv(argc, argv) } {
-                        Ok(args) => super::$ident::sm_setcred(pamh, args, flags),
-                        Err(e) => e,
-                    }
-                })
+                unsafe {
+                    $crate::macros::invoke_hook(argc, argv, |args| {
+                        super::$ident::sm_setcred(pamh, args, flags)
+                    })
+                }
             }
         }
     };
@@ -154,8 +148,7 @@ macro_rules! pam_try {
     };
 }
 
-#[doc(hidden)]
-pub fn __panic_guard<F: FnOnce() -> PamResultCode>(f: F) -> PamResultCode {
+fn panic_guard<F: FnOnce() -> PamResultCode>(f: F) -> PamResultCode {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)).unwrap_or(PamResultCode::PAM_ABORT)
 }
 
@@ -163,28 +156,16 @@ pub fn __panic_guard<F: FnOnce() -> PamResultCode>(f: F) -> PamResultCode {
 ///
 /// # Errors
 ///
-/// - [`PamResultCode::PAM_ABORT`] if `argc` is negative.
-/// - [`PamResultCode::PAM_ABORT`] if `argv` is null while `argc > 0`.
-/// - [`PamResultCode::PAM_ABORT`] if any element of `argv` (within `argc`) is null.
+/// - [`PamResultCode::PAM_ABORT`] if any element of `argv` is null.
 ///
 /// # Safety
 ///
-/// When `argc > 0`, `argv` must point to an array of at least `argc` valid
-/// `*const c_char` entries; each non-null entry must point to a NUL-terminated
-/// C string that outlives `'a`.
-#[doc(hidden)]
-#[allow(clippy::similar_names)]
-pub unsafe fn extract_argv<'a>(
-    argc: std::os::raw::c_int,
-    argv: *const *const std::os::raw::c_char,
-) -> Result<Vec<&'a std::ffi::CStr>, PamResultCode> {
-    if argc < 0 || (argc > 0 && argv.is_null()) {
-        return Err(PamResultCode::PAM_ABORT);
-    }
-    (0..argc)
-        .map(|o| {
-            #[allow(clippy::cast_sign_loss)]
-            let p = unsafe { *argv.add(o as usize) };
+/// - Each non-null argument must point to a null-terminated C string that outlives the slice.
+unsafe fn extract_argv(
+    argv: &[*const std::os::raw::c_char],
+) -> Result<Vec<&std::ffi::CStr>, PamResultCode> {
+    argv.iter()
+        .map(|&p| {
             if p.is_null() {
                 Err(PamResultCode::PAM_ABORT)
             } else {
@@ -192,6 +173,36 @@ pub unsafe fn extract_argv<'a>(
             }
         })
         .collect()
+}
+
+/// Validates argc/argv, catches panics, and invokes a `PamHooks` method.
+///
+/// # Safety
+///
+/// - When `argc > 0`, `argv` must point to an array of `argc` valid `*const c_char` entries.
+/// - Each non-null entry must point to a null-terminated C string valid for the duration of `hook`.
+#[doc(hidden)]
+#[allow(clippy::similar_names)]
+pub unsafe fn invoke_hook(
+    argc: std::os::raw::c_int,
+    argv: *const *const std::os::raw::c_char,
+    hook: impl FnOnce(Vec<&std::ffi::CStr>) -> PamResultCode,
+) -> PamResultCode {
+    panic_guard(|| {
+        if argc < 0 || (argc > 0 && argv.is_null()) {
+            return PamResultCode::PAM_ABORT;
+        }
+        #[allow(clippy::cast_sign_loss)]
+        let argv: &[*const std::os::raw::c_char] = if argc == 0 {
+            &[]
+        } else {
+            unsafe { std::slice::from_raw_parts(argv, argc as usize) }
+        };
+        match unsafe { extract_argv(argv) } {
+            Ok(args) => hook(args),
+            Err(e) => e,
+        }
+    })
 }
 
 #[cfg(test)]
@@ -209,40 +220,26 @@ pub mod test {
 
     #[test]
     fn panic_returns_error_code() {
-        let code = super::__panic_guard(|| panic!("intentional"));
+        let code = super::panic_guard(|| panic!("intentional"));
         assert_eq!(code, PamResultCode::PAM_ABORT);
     }
 
     #[test]
     fn test_extract_argv() {
-        // Error cases
-        assert_eq!(
-            // argc < 0
-            unsafe { super::extract_argv(-1, ptr::null()) }.unwrap_err(),
-            PamResultCode::PAM_ABORT
-        );
-        assert_eq!(
-            // argc > 0, argv is null
-            unsafe { super::extract_argv(2, ptr::null()) }.unwrap_err(),
-            PamResultCode::PAM_ABORT
-        );
+        // Error case: one element is null
         let with_null: [*const c_char; 2] = [c"first".as_ptr(), ptr::null()];
         assert_eq!(
-            // argc > 0, one element is null
-            unsafe { super::extract_argv(2, with_null.as_ptr()) }.unwrap_err(),
+            unsafe { super::extract_argv(&with_null) }.unwrap_err(),
             PamResultCode::PAM_ABORT
         );
 
         // Success: no arguments
-        assert!(
-            unsafe { super::extract_argv(0, ptr::null()) }
-                .unwrap()
-                .is_empty()
-        );
+        let empty: [*const c_char; 0] = [];
+        assert!(unsafe { super::extract_argv(&empty) }.unwrap().is_empty());
 
         // Success: all elements are valid
         let valid: [*const c_char; 2] = [c"first".as_ptr(), c"second".as_ptr()];
-        let args = unsafe { super::extract_argv(2, valid.as_ptr()) }.unwrap();
+        let args = unsafe { super::extract_argv(&valid) }.unwrap();
         assert_eq!(args.len(), 2);
         assert_eq!(args[0].to_str().unwrap(), "first");
         assert_eq!(args[1].to_str().unwrap(), "second");

--- a/pam/src/macros.rs
+++ b/pam/src/macros.rs
@@ -6,6 +6,7 @@ use crate::constants::PamResultCode;
 ///
 /// ## Errors
 ///
+/// - [`PamResultCode::PAM_ABORT`] if the PAM handle is null.
 /// - [`PamResultCode::PAM_ABORT`] if `argc` is negative.
 /// - [`PamResultCode::PAM_ABORT`] if `argv` is null and `argc` is positive.
 /// - [`PamResultCode::PAM_ABORT`] if any element of `argv` is unexpectedly null.
@@ -47,13 +48,13 @@ macro_rules! pam_hooks {
 
             #[unsafe(no_mangle)]
             pub unsafe extern "C" fn pam_sm_acct_mgmt(
-                pamh: &mut PamHandle,
+                pamh: *mut PamHandle,
                 flags: PamFlag,
                 argc: c_int,
                 argv: *const *const c_char,
             ) -> PamResultCode {
                 unsafe {
-                    $crate::macros::invoke_hook(argc, argv, |args| {
+                    $crate::macros::invoke_hook(pamh, argc, argv, |pamh, args| {
                         super::$ident::acct_mgmt(pamh, args, flags)
                     })
                 }
@@ -61,13 +62,13 @@ macro_rules! pam_hooks {
 
             #[unsafe(no_mangle)]
             pub unsafe extern "C" fn pam_sm_authenticate(
-                pamh: &mut PamHandle,
+                pamh: *mut PamHandle,
                 flags: PamFlag,
                 argc: c_int,
                 argv: *const *const c_char,
             ) -> PamResultCode {
                 unsafe {
-                    $crate::macros::invoke_hook(argc, argv, |args| {
+                    $crate::macros::invoke_hook(pamh, argc, argv, |pamh, args| {
                         super::$ident::sm_authenticate(pamh, args, flags)
                     })
                 }
@@ -75,13 +76,13 @@ macro_rules! pam_hooks {
 
             #[unsafe(no_mangle)]
             pub unsafe extern "C" fn pam_sm_chauthtok(
-                pamh: &mut PamHandle,
+                pamh: *mut PamHandle,
                 flags: PamFlag,
                 argc: c_int,
                 argv: *const *const c_char,
             ) -> PamResultCode {
                 unsafe {
-                    $crate::macros::invoke_hook(argc, argv, |args| {
+                    $crate::macros::invoke_hook(pamh, argc, argv, |pamh, args| {
                         super::$ident::sm_chauthtok(pamh, args, flags)
                     })
                 }
@@ -89,13 +90,13 @@ macro_rules! pam_hooks {
 
             #[unsafe(no_mangle)]
             pub unsafe extern "C" fn pam_sm_close_session(
-                pamh: &mut PamHandle,
+                pamh: *mut PamHandle,
                 flags: PamFlag,
                 argc: c_int,
                 argv: *const *const c_char,
             ) -> PamResultCode {
                 unsafe {
-                    $crate::macros::invoke_hook(argc, argv, |args| {
+                    $crate::macros::invoke_hook(pamh, argc, argv, |pamh, args| {
                         super::$ident::sm_close_session(pamh, args, flags)
                     })
                 }
@@ -103,13 +104,13 @@ macro_rules! pam_hooks {
 
             #[unsafe(no_mangle)]
             pub unsafe extern "C" fn pam_sm_open_session(
-                pamh: &mut PamHandle,
+                pamh: *mut PamHandle,
                 flags: PamFlag,
                 argc: c_int,
                 argv: *const *const c_char,
             ) -> PamResultCode {
                 unsafe {
-                    $crate::macros::invoke_hook(argc, argv, |args| {
+                    $crate::macros::invoke_hook(pamh, argc, argv, |pamh, args| {
                         super::$ident::sm_open_session(pamh, args, flags)
                     })
                 }
@@ -117,13 +118,13 @@ macro_rules! pam_hooks {
 
             #[unsafe(no_mangle)]
             pub unsafe extern "C" fn pam_sm_setcred(
-                pamh: &mut PamHandle,
+                pamh: *mut PamHandle,
                 flags: PamFlag,
                 argc: c_int,
                 argv: *const *const c_char,
             ) -> PamResultCode {
                 unsafe {
-                    $crate::macros::invoke_hook(argc, argv, |args| {
+                    $crate::macros::invoke_hook(pamh, argc, argv, |pamh, args| {
                         super::$ident::sm_setcred(pamh, args, flags)
                     })
                 }
@@ -175,20 +176,34 @@ unsafe fn extract_argv(
         .collect()
 }
 
-/// Validates argc/argv, catches panics, and invokes a `PamHooks` method.
+/// Validates the handle and argc/argv, catches panics, and invokes a `PamHooks` method.
+///
+/// # Errors
+///
+/// - [`PamResultCode::PAM_ABORT`] if `pamh` is null.
+/// - [`PamResultCode::PAM_ABORT`] if `argc` is negative.
+/// - [`PamResultCode::PAM_ABORT`] if `argv` is null and `argc` is positive.
+/// - [`PamResultCode::PAM_ABORT`] if any element of `argv` is null.
+/// - [`PamResultCode::PAM_ABORT`] if `hook` panics.
 ///
 /// # Safety
 ///
+/// - When non-null, `pamh` must be a valid, aligned pointer to a `PamHandle` usable for the duration of `hook`.
 /// - When `argc > 0`, `argv` must point to an array of `argc` valid `*const c_char` entries.
 /// - Each non-null entry must point to a null-terminated C string valid for the duration of `hook`.
 #[doc(hidden)]
 #[allow(clippy::similar_names)]
 pub unsafe fn invoke_hook(
+    pamh: *mut crate::module::PamHandle,
     argc: std::os::raw::c_int,
     argv: *const *const std::os::raw::c_char,
-    hook: impl FnOnce(Vec<&std::ffi::CStr>) -> PamResultCode,
+    hook: impl FnOnce(&mut crate::module::PamHandle, Vec<&std::ffi::CStr>) -> PamResultCode,
 ) -> PamResultCode {
     panic_guard(|| {
+        // PAM should always hand us a valid handle
+        let Some(pamh) = (unsafe { pamh.as_mut() }) else {
+            return PamResultCode::PAM_ABORT;
+        };
         if argc < 0 || (argc > 0 && argv.is_null()) {
             return PamResultCode::PAM_ABORT;
         }
@@ -199,18 +214,19 @@ pub unsafe fn invoke_hook(
             unsafe { std::slice::from_raw_parts(argv, argc as usize) }
         };
         match unsafe { extract_argv(argv) } {
-            Ok(args) => hook(args),
+            Ok(args) => hook(pamh, args),
             Err(e) => e,
         }
     })
 }
 
 #[cfg(test)]
-#[allow(clippy::panic, clippy::unwrap_used)]
+#[allow(clippy::panic, clippy::unwrap_used, clippy::needless_pass_by_value)]
 pub mod test {
     use crate::constants::PamResultCode;
-    use crate::module::PamHooks;
-    use std::os::raw::c_char;
+    use crate::module::{PamHandle, PamHooks};
+    use std::ffi::CStr;
+    use std::os::raw::{c_char, c_int};
     use std::ptr;
 
     struct Foo;
@@ -222,6 +238,90 @@ pub mod test {
     fn panic_returns_error_code() {
         let code = super::panic_guard(|| panic!("intentional"));
         assert_eq!(code, PamResultCode::PAM_ABORT);
+    }
+
+    /// Test hook returning `PAM_SUCCESS`, distinct from `PAM_ABORT` so an unexpected run is caught.
+    fn hook_success(_pamh: &mut PamHandle, _args: Vec<&CStr>) -> PamResultCode {
+        PamResultCode::PAM_SUCCESS
+    }
+
+    /// Test hook that always panics, used to verify a panicking hook becomes `PAM_ABORT`.
+    fn hook_panic(_pamh: &mut PamHandle, _args: Vec<&CStr>) -> PamResultCode {
+        panic!("hook panicked");
+    }
+
+    #[test]
+    fn invoke_hook_validation() {
+        struct Case {
+            pamh: *mut PamHandle,
+            argc: c_int,
+            argv: *const *const c_char,
+            hook: fn(&mut PamHandle, Vec<&CStr>) -> PamResultCode,
+            expected: PamResultCode,
+        }
+
+        // Mock "valid" PAM handle for testing
+        let pamh = ptr::NonNull::<PamHandle>::dangling().as_ptr();
+
+        // Argv arrays
+        let one_null: [*const c_char; 1] = [ptr::null()];
+        let two_valid: [*const c_char; 2] = [c"first".as_ptr(), c"second".as_ptr()];
+
+        let cases = [
+            // Null PAM handle is rejected before the hook runs
+            Case {
+                pamh: ptr::null_mut(),
+                argc: 0,
+                argv: ptr::null(),
+                hook: hook_success,
+                expected: PamResultCode::PAM_ABORT,
+            },
+            // Negative argc is rejected
+            Case {
+                pamh,
+                argc: -1,
+                argv: ptr::null(),
+                hook: hook_success,
+                expected: PamResultCode::PAM_ABORT,
+            },
+            // Null argv with positive argc is rejected
+            Case {
+                pamh,
+                argc: 1,
+                argv: ptr::null(),
+                hook: hook_success,
+                expected: PamResultCode::PAM_ABORT,
+            },
+            // A null element within argv is rejected
+            Case {
+                pamh,
+                argc: 1,
+                argv: one_null.as_ptr(),
+                hook: hook_success,
+                expected: PamResultCode::PAM_ABORT,
+            },
+            // A panicking hook is contained and reported as an abort
+            Case {
+                pamh,
+                argc: 0,
+                argv: ptr::null(),
+                hook: hook_panic,
+                expected: PamResultCode::PAM_ABORT,
+            },
+            // Happy path: a valid handle and argv invoke the hook
+            Case {
+                pamh,
+                argc: 2,
+                argv: two_valid.as_ptr(),
+                hook: hook_success,
+                expected: PamResultCode::PAM_SUCCESS,
+            },
+        ];
+
+        for case in cases {
+            let actual = unsafe { super::invoke_hook(case.pamh, case.argc, case.argv, case.hook) };
+            assert_eq!(case.expected, actual);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Three commits:

1. A macro refactor to move as much logic out of the pam_hooks macro and into "normal" functions that can be tested more easily
2. A fix for Conv::send so that it rejects unsupported PAM message styles; also removes support for the binary message style because the send internals assume strings, not arbitrary bytes.
3. Handle the edge case of the PAM handle pointer itself being null 