### PR TITLE
Handle spelling mistake in pamtester output

### DIFF
--- a/pam/tests/integration/test_username.rs
+++ b/pam/tests/integration/test_username.rs
@@ -11,7 +11,13 @@ fn test_username_example_module() {
         &[],
     );
 
-    let expected_stdout = "pamtester: successfully opened a session\n";
+    // The pamtester version shipped by popular distributions (such as Fedora 44 and earlier)
+    // has a spelling mistake in its output. This construct ensures that the test succeeds
+    // even in the face of this circumstance
+    let expected_stdout = [
+        "pamtester: successfully opened a session\n",
+        "pamtester: sucessfully opened a session\n",
+    ];
     let expected_stderr = format!("username: {test_username}\n");
     let actual_stdout = String::from_utf8_lossy(&output.stdout);
     let actual_stderr = String::from_utf8_lossy(&output.stderr);
@@ -20,6 +26,9 @@ fn test_username_example_module() {
         output.status.success(),
         "stdout: {actual_stdout} stderr: {actual_stderr}"
     );
-    assert_eq!(expected_stdout, String::from_utf8_lossy(&output.stdout));
+    assert!(
+        expected_stdout.contains(&actual_stdout.as_ref()),
+        "stdout: {actual_stdout} stderr: {actual_stderr}"
+    );
     assert_eq!(expected_stderr, String::from_utf8_lossy(&output.stderr));
 }


### PR DESCRIPTION
Funnily enough, the version of pamtester that ships with current Fedora: pamtester-0.1.2-30.fc44 has a spelling mistake in its output: `pamtester: sucessfully opened a session`. This diff handles both the current spelling error and the correct spelling at the cost of introducing regex to dev-dependencies